### PR TITLE
Add delegation chain verification and APIs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,3 +19,10 @@ The credential-service repository now follows an idiomatic Go layout that separa
 2. **Store/Queue**: Credentials persisted via `pgx` (if configured) and issuance jobs emitted to RabbitMQ for background processing.
 3. **Verify**: Presentation posted to `cmd/verifier` → handler (`internal/verifier`) → validation rules in `internal/domain`.
 4. **Future**: Trust registry and delegation rules will extend `internal/domain` and share middleware/config utilities.
+
+## Delegation and Agent Identity
+- Credentials can be delegated from one DID to another, enabling agents to act with constrained authority.
+- Each delegation step must shrink scope and shorten time-to-live; children cannot outlive or outrange parents.
+- Verification enforces a maximum delegation depth to cap chain length.
+- Verifier responses surface both the active subject and who they are acting on behalf of.
+- This makes agent actions auditable while preserving least-privilege semantics.

--- a/internal/domain/delegation.go
+++ b/internal/domain/delegation.go
@@ -1,13 +1,59 @@
 package domain
 
-// Delegation represents a placeholder for delegation logic between tenants or actors.
-type Delegation struct {
-	ParentScope string
-	ChildScope  string
+import "time"
+
+// DelegationRequest captures the input needed to mint a delegated credential.
+type DelegationRequest struct {
+	ParentCredentialToken string
+	DelegateDID           string
+	Scope                 []string
+	TTL                   time.Duration
 }
 
-// Validate ensures a child scope cannot exceed the parent. Implementation pending.
-func (d Delegation) Validate() bool {
-	// TODO: implement real delegation validation rules
-	return d.ChildScope == "" || d.ChildScope == d.ParentScope
+// DelegationInfo represents a resolved delegation relationship.
+type DelegationInfo struct {
+	ParentID        string
+	DelegatorDID    string
+	DelegateDID     string
+	Scope           []string
+	ExpiresAt       time.Time
+	DelegationDepth int
+}
+
+// IsScopeSubset checks whether the child scope is a subset of the parent scope.
+func IsScopeSubset(parentScope, childScope []string) bool {
+	if len(childScope) == 0 {
+		return true
+	}
+
+	parentSet := make(map[string]struct{}, len(parentScope))
+	for _, s := range parentScope {
+		parentSet[s] = struct{}{}
+	}
+
+	for _, s := range childScope {
+		if _, ok := parentSet[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// IsTTLWithinParent ensures a child credential expires no later than the parent.
+func IsTTLWithinParent(parentExpiresAt, childExpiresAt time.Time) bool {
+	if parentExpiresAt.IsZero() {
+		return true
+	}
+	if childExpiresAt.IsZero() {
+		return false
+	}
+	return !childExpiresAt.After(parentExpiresAt)
+}
+
+// IsDepthAllowed verifies the delegation depth does not exceed the configured maximum.
+func IsDepthAllowed(depth, maxDepth int) bool {
+	if maxDepth <= 0 {
+		return true
+	}
+	return depth <= maxDepth
 }

--- a/internal/domain/delegation_test.go
+++ b/internal/domain/delegation_test.go
@@ -1,9 +1,56 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestDelegationValidationRules(t *testing.T) {
-	t.Run("child scope must not exceed parent", func(t *testing.T) {
-		t.Skip("TODO: implement delegation scope validation")
-	})
+func TestIsScopeSubset(t *testing.T) {
+	parent := []string{"read", "write"}
+
+	tests := []struct {
+		name   string
+		child  []string
+		expect bool
+	}{
+		{"child subset", []string{"read"}, true},
+		{"child equal", []string{"read", "write"}, true},
+		{"child empty", nil, true},
+		{"child expands", []string{"read", "delete"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsScopeSubset(parent, tt.child); got != tt.expect {
+				t.Fatalf("expected %v, got %v", tt.expect, got)
+			}
+		})
+	}
+}
+
+func TestIsTTLWithinParent(t *testing.T) {
+	now := time.Now()
+	parent := now.Add(5 * time.Minute)
+	childSooner := now.Add(3 * time.Minute)
+	childLater := now.Add(10 * time.Minute)
+
+	if !IsTTLWithinParent(parent, childSooner) {
+		t.Fatalf("expected child expiring sooner to be allowed")
+	}
+
+	if IsTTLWithinParent(parent, childLater) {
+		t.Fatalf("expected child expiring later to be rejected")
+	}
+}
+
+func TestIsDepthAllowed(t *testing.T) {
+	maxDepth := 3
+
+	if !IsDepthAllowed(2, maxDepth) {
+		t.Fatalf("depth within max should be allowed")
+	}
+
+	if IsDepthAllowed(4, maxDepth) {
+		t.Fatalf("depth beyond max should not be allowed")
+	}
 }

--- a/internal/domain/vc_verify.go
+++ b/internal/domain/vc_verify.go
@@ -19,6 +19,10 @@ var (
 	ErrIssuedInFuture     = errors.New("credential is issued in the future")
 	ErrUntrustedIssuer    = errors.New("issuer is not trusted")
 	ErrUnexpectedAudience = errors.New("unexpected audience")
+	ErrInvalidDelegation  = errors.New("invalid delegation chain")
+	ErrDelegationScope    = errors.New("delegated scope must be subset of parent")
+	ErrDelegationTTL      = errors.New("delegated credential expires after parent")
+	ErrDelegationDepth    = errors.New("delegation depth exceeded")
 )
 
 // VerificationResult captures the verified credential payload.
@@ -26,67 +30,174 @@ type VerificationResult struct {
 	Credential VerifiableCredential
 }
 
+// DelegationChainResult captures details of a verified delegation chain.
+type DelegationChainResult struct {
+	Credentials     []VerifiableCredential
+	CurrentSubject  string
+	RootDelegator   string
+	DelegationDepth int
+}
+
 // VerifierDependencies holds collaborators needed for verification.
 type VerifierDependencies struct {
 	ResolveIssuerPublicKey func(issuerDID string) (crypto.PublicKey, error)
 }
 
-// VerifyCredential parses and verifies a compact JWS/JWT credential token.
-func VerifyCredential(token string, deps VerifierDependencies, expectedAudience string, now time.Time) (*VerificationResult, error) {
+// VerificationOptions captures optional verification constraints.
+type VerificationOptions struct {
+	ExpectedAudience   string
+	MaxDelegationDepth int
+}
+
+// VerifyCredentialChain parses and verifies a chain of credential tokens.
+func VerifyCredentialChain(tokens []string, deps VerifierDependencies, opts VerificationOptions, now time.Time) (*DelegationChainResult, error) {
 	if deps.ResolveIssuerPublicKey == nil {
 		return nil, fmt.Errorf("resolve issuer public key is required: %w", ErrInvalidToken)
 	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no credentials supplied: %w", ErrInvalidDelegation)
+	}
 
+	maxDepth := opts.MaxDelegationDepth
+	if maxDepth == 0 {
+		maxDepth = 3
+	}
+
+	credentials := make([]VerifiableCredential, 0, len(tokens))
+	for idx, token := range tokens {
+		expectedAudience := ""
+		if idx == len(tokens)-1 {
+			expectedAudience = opts.ExpectedAudience
+		}
+
+		credential, err := verifySingleCredential(token, deps, expectedAudience, now)
+		if err != nil {
+			return nil, err
+		}
+
+		credentials = append(credentials, credential)
+
+		if idx == 0 {
+			continue
+		}
+
+		parent := credentials[idx-1]
+		child := credential
+
+		if !IsDepthAllowed(idx, maxDepth) {
+			return nil, ErrDelegationDepth
+		}
+
+		if !IsScopeSubset(ScopeFromClaims(parent.Claims), ScopeFromClaims(child.Claims)) {
+			return nil, ErrDelegationScope
+		}
+
+		if !IsTTLWithinParent(parent.ExpiresAt, child.ExpiresAt) {
+			return nil, ErrDelegationTTL
+		}
+	}
+
+	result := &DelegationChainResult{
+		Credentials:     credentials,
+		CurrentSubject:  credentials[len(credentials)-1].Subject,
+		RootDelegator:   credentials[0].Subject,
+		DelegationDepth: len(credentials) - 1,
+	}
+
+	if !IsDepthAllowed(result.DelegationDepth, maxDepth) {
+		return nil, ErrDelegationDepth
+	}
+
+	return result, nil
+}
+
+// VerifyCredential parses and verifies a compact JWS/JWT credential token.
+func VerifyCredential(token string, deps VerifierDependencies, expectedAudience string, now time.Time) (*VerificationResult, error) {
+	res, err := VerifyCredentialChain([]string{token}, deps, VerificationOptions{ExpectedAudience: expectedAudience, MaxDelegationDepth: 1}, now)
+	if err != nil {
+		return nil, err
+	}
+	return &VerificationResult{Credential: res.Credentials[0]}, nil
+}
+
+func verifySingleCredential(token string, deps VerifierDependencies, expectedAudience string, now time.Time) (VerifiableCredential, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return nil, ErrInvalidToken
+		return VerifiableCredential{}, ErrInvalidToken
 	}
 
 	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, ErrInvalidToken
+		return VerifiableCredential{}, ErrInvalidToken
 	}
 
 	var credential VerifiableCredential
 	if err := json.Unmarshal(payloadBytes, &credential); err != nil {
-		return nil, ErrInvalidToken
+		return VerifiableCredential{}, ErrInvalidToken
 	}
 
 	publicKey, err := deps.ResolveIssuerPublicKey(credential.Issuer)
 	if err != nil {
-		return nil, fmt.Errorf("resolve issuer: %w", ErrUntrustedIssuer)
+		return VerifiableCredential{}, fmt.Errorf("resolve issuer: %w", ErrUntrustedIssuer)
 	}
 
 	edKey, ok := publicKey.(ed25519.PublicKey)
 	if !ok {
-		return nil, ErrInvalidToken
+		return VerifiableCredential{}, ErrInvalidToken
 	}
 
 	signingInput := parts[0] + "." + parts[1]
 	signatureBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
 	if err != nil {
-		return nil, ErrInvalidToken
+		return VerifiableCredential{}, ErrInvalidToken
 	}
 
 	if !ed25519.Verify(edKey, []byte(signingInput), signatureBytes) {
-		return nil, ErrInvalidSignature
+		return VerifiableCredential{}, ErrInvalidSignature
 	}
 
 	if !credential.ExpiresAt.IsZero() && !now.Before(credential.ExpiresAt) {
-		return nil, ErrExpiredCredential
+		return VerifiableCredential{}, ErrExpiredCredential
 	}
 
 	// Allow small clock skew; reject tokens issued far in the future.
 	if !credential.IssuedAt.IsZero() && credential.IssuedAt.After(now.Add(1*time.Minute)) {
-		return nil, ErrIssuedInFuture
+		return VerifiableCredential{}, ErrIssuedInFuture
 	}
 
 	if expectedAudience != "" {
 		aud, _ := credential.Claims["aud"].(string)
 		if aud != expectedAudience {
-			return nil, ErrUnexpectedAudience
+			return VerifiableCredential{}, ErrUnexpectedAudience
 		}
 	}
 
-	return &VerificationResult{Credential: credential}, nil
+	return credential, nil
+}
+
+func ScopeFromClaims(claims map[string]interface{}) []string {
+	if claims == nil {
+		return nil
+	}
+	scopeVal, ok := claims["scope"]
+	if !ok {
+		return nil
+	}
+
+	switch v := scopeVal.(type) {
+	case []string:
+		return append([]string{}, v...)
+	case []interface{}:
+		res := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				res = append(res, s)
+			}
+		}
+		return res
+	case string:
+		return []string{v}
+	default:
+		return nil
+	}
 }

--- a/internal/domain/vc_verify_test.go
+++ b/internal/domain/vc_verify_test.go
@@ -39,6 +39,124 @@ func TestVerifyCredentialSuccess(t *testing.T) {
 	}
 }
 
+func TestVerifyCredentialChainNoDelegation(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	token, err := IssueBasicCredential("did:jwk:issuer", "did:jwk:subject", priv, 5*time.Minute, map[string]interface{}{"aud": "example"})
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	deps := VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
+		if issuer != "did:jwk:issuer" {
+			return nil, errors.New("unknown issuer")
+		}
+		return pub, nil
+	}}
+
+	result, err := VerifyCredentialChain([]string{token}, deps, VerificationOptions{ExpectedAudience: "example", MaxDelegationDepth: 2}, time.Now())
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	if result.DelegationDepth != 0 {
+		t.Fatalf("expected depth 0, got %d", result.DelegationDepth)
+	}
+
+	if result.CurrentSubject != "did:jwk:subject" || result.RootDelegator != "did:jwk:subject" {
+		t.Fatalf("unexpected delegation parties: %+v", result)
+	}
+}
+
+func TestVerifyCredentialChainDelegated(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	parentToken, err := IssueBasicCredential("did:jwk:issuer", "did:jwk:parent", priv, 10*time.Minute, map[string]interface{}{"scope": []string{"read", "write"}})
+	if err != nil {
+		t.Fatalf("issue parent: %v", err)
+	}
+
+	childToken, err := IssueBasicCredential("did:jwk:issuer", "did:jwk:agent", priv, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}, "aud": "api"})
+	if err != nil {
+		t.Fatalf("issue child: %v", err)
+	}
+
+	deps := VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
+		if issuer != "did:jwk:issuer" {
+			return nil, errors.New("unknown issuer")
+		}
+		return pub, nil
+	}}
+
+	result, err := VerifyCredentialChain([]string{parentToken, childToken}, deps, VerificationOptions{ExpectedAudience: "api", MaxDelegationDepth: 3}, time.Now())
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	if result.DelegationDepth != 1 {
+		t.Fatalf("expected delegation depth 1, got %d", result.DelegationDepth)
+	}
+
+	if result.RootDelegator != "did:jwk:parent" || result.CurrentSubject != "did:jwk:agent" {
+		t.Fatalf("unexpected parties: %+v", result)
+	}
+}
+
+func TestVerifyCredentialChainScopeExpansionFails(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	parentToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:parent", priv, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+	childToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:agent", priv, 3*time.Minute, map[string]interface{}{"scope": []string{"read", "write"}})
+
+	deps := VerifierDependencies{ResolveIssuerPublicKey: func(string) (crypto.PublicKey, error) { return pub, nil }}
+
+	if _, err := VerifyCredentialChain([]string{parentToken, childToken}, deps, VerificationOptions{MaxDelegationDepth: 2}, time.Now()); !errors.Is(err, ErrDelegationScope) {
+		t.Fatalf("expected ErrDelegationScope, got %v", err)
+	}
+}
+
+func TestVerifyCredentialChainTTLExpansionFails(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	parentToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:parent", priv, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+	childToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:agent", priv, 10*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+
+	deps := VerifierDependencies{ResolveIssuerPublicKey: func(string) (crypto.PublicKey, error) { return pub, nil }}
+
+	if _, err := VerifyCredentialChain([]string{parentToken, childToken}, deps, VerificationOptions{MaxDelegationDepth: 2}, time.Now()); !errors.Is(err, ErrDelegationTTL) {
+		t.Fatalf("expected ErrDelegationTTL, got %v", err)
+	}
+}
+
+func TestVerifyCredentialChainDepthLimit(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	parentToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:parent", priv, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+	childToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:agent", priv, 4*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+	grandChildToken, _ := IssueBasicCredential("did:jwk:issuer", "did:jwk:agent-2", priv, 3*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+
+	deps := VerifierDependencies{ResolveIssuerPublicKey: func(string) (crypto.PublicKey, error) { return pub, nil }}
+
+	if _, err := VerifyCredentialChain([]string{parentToken, childToken, grandChildToken}, deps, VerificationOptions{MaxDelegationDepth: 1}, time.Now()); !errors.Is(err, ErrDelegationDepth) {
+		t.Fatalf("expected ErrDelegationDepth, got %v", err)
+	}
+}
+
 func TestVerifyCredentialExpired(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	token, err := IssueBasicCredential("did:jwk:issuer", "did:jwk:subject", priv, time.Minute, nil)

--- a/internal/httpx/issuer_handlers.go
+++ b/internal/httpx/issuer_handlers.go
@@ -1,7 +1,9 @@
 package httpx
 
 import (
+	"crypto"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -20,6 +22,14 @@ type IssueRequest struct {
 // IssueResponse represents the response payload after issuance.
 type IssueResponse struct {
 	Credential string `json:"credential"`
+}
+
+// DelegateRequest represents the payload for issuing delegated credentials.
+type DelegateRequest struct {
+	ParentCredential string   `json:"parent_credential"`
+	DelegateDID      string   `json:"delegate_did"`
+	Scope            []string `json:"scope"`
+	TTLSeconds       int64    `json:"ttl_seconds"`
 }
 
 // RegisterIssuerRoutes wires issuer HTTP routes into the provided mux.
@@ -60,6 +70,97 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 		}
 
 		token, err := domain.IssueBasicCredential(issuerDID, req.SubjectDID, signer, ttl, req.Claims)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, "issuance_error", err.Error())
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: token})
+	})
+
+	mux.HandleFunc("/v1/credentials/delegate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			WriteError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+
+		var req DelegateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			WriteError(w, http.StatusBadRequest, "bad_request", "invalid request payload")
+			return
+		}
+
+		if req.ParentCredential == "" || req.DelegateDID == "" {
+			WriteError(w, http.StatusBadRequest, "invalid_request", "parent_credential and delegate_did are required")
+			return
+		}
+		if len(req.Scope) == 0 {
+			WriteError(w, http.StatusBadRequest, "invalid_request", "scope is required")
+			return
+		}
+
+		ttl := time.Duration(req.TTLSeconds) * time.Second
+		if ttl <= 0 {
+			WriteError(w, http.StatusBadRequest, "invalid_request", "ttl_seconds must be positive")
+			return
+		}
+
+		signer, err := store.GetSigningKey(cfg.DefaultTenantID)
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, "keystore_error", err.Error())
+			return
+		}
+
+		issuerDID, err := domain.DIDFromPublicKey(signer.Public())
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, "did_error", err.Error())
+			return
+		}
+
+		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
+			if issuer != issuerDID {
+				return nil, domain.ErrUntrustedIssuer
+			}
+			return signer.Public(), nil
+		}}
+
+		now := time.Now()
+		parentResult, err := domain.VerifyCredentialChain([]string{req.ParentCredential}, deps, domain.VerificationOptions{MaxDelegationDepth: 1}, now)
+		if err != nil {
+			status := http.StatusBadRequest
+			switch {
+			case errors.Is(err, domain.ErrUntrustedIssuer):
+				status = http.StatusForbidden
+			case errors.Is(err, domain.ErrExpiredCredential), errors.Is(err, domain.ErrInvalidSignature):
+				status = http.StatusUnauthorized
+			}
+			WriteError(w, status, "invalid_parent", err.Error())
+			return
+		}
+
+		parentCred := parentResult.Credentials[0]
+		parentScope := domain.ScopeFromClaims(parentCred.Claims)
+		if !domain.IsScopeSubset(parentScope, req.Scope) {
+			WriteError(w, http.StatusBadRequest, "invalid_scope", "delegated scope must be within parent scope")
+			return
+		}
+
+		expiresAt := now.Add(ttl)
+		if !domain.IsTTLWithinParent(parentCred.ExpiresAt, expiresAt) {
+			WriteError(w, http.StatusBadRequest, "invalid_ttl", "delegated credential must expire before parent")
+			return
+		}
+
+		claims := map[string]interface{}{
+			"scope":     req.Scope,
+			"parent_id": parentCred.ID,
+		}
+		if aud, ok := parentCred.Claims["aud"]; ok {
+			claims["aud"] = aud
+		}
+
+		token, err := domain.IssueBasicCredential(issuerDID, req.DelegateDID, signer, ttl, claims)
 		if err != nil {
 			WriteError(w, http.StatusInternalServerError, "issuance_error", err.Error())
 			return

--- a/internal/httpx/issuer_handlers_test.go
+++ b/internal/httpx/issuer_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bradtumy/credential-service/internal/config"
+	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/keystore"
 )
 
@@ -59,6 +60,109 @@ func TestIssueHandlerMissingSubject(t *testing.T) {
 	payload, _ := json.Marshal(body)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/issue", bytes.NewReader(payload))
+	recorder := httptest.NewRecorder()
+
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", recorder.Code)
+	}
+}
+
+func TestDelegateHandlerSuccess(t *testing.T) {
+	store := keystore.NewMemoryKeyStore()
+	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
+	mux := http.NewServeMux()
+	RegisterIssuerRoutes(mux, store, cfg)
+
+	signer, err := store.GetSigningKey(cfg.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("get signing key: %v", err)
+	}
+	issuerDID, err := domain.DIDFromPublicKey(signer.Public())
+	if err != nil {
+		t.Fatalf("did from key: %v", err)
+	}
+
+	parentToken, err := domain.IssueBasicCredential(issuerDID, "did:jwk:parent", signer, 10*time.Minute, map[string]interface{}{"scope": []string{"read", "write"}})
+	if err != nil {
+		t.Fatalf("issue parent: %v", err)
+	}
+
+	body := DelegateRequest{
+		ParentCredential: parentToken,
+		DelegateDID:      "did:jwk:agent",
+		Scope:            []string{"read"},
+		TTLSeconds:       int64((5 * time.Minute).Seconds()),
+	}
+	payload, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/delegate", bytes.NewReader(payload))
+	recorder := httptest.NewRecorder()
+
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", recorder.Code)
+	}
+
+	var resp IssueResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Credential == "" {
+		t.Fatalf("expected delegated credential")
+	}
+}
+
+func TestDelegateHandlerScopeExpansion(t *testing.T) {
+	store := keystore.NewMemoryKeyStore()
+	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
+	mux := http.NewServeMux()
+	RegisterIssuerRoutes(mux, store, cfg)
+
+	signer, _ := store.GetSigningKey(cfg.DefaultTenantID)
+	issuerDID, _ := domain.DIDFromPublicKey(signer.Public())
+	parentToken, _ := domain.IssueBasicCredential(issuerDID, "did:jwk:parent", signer, 10*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+
+	body := DelegateRequest{
+		ParentCredential: parentToken,
+		DelegateDID:      "did:jwk:agent",
+		Scope:            []string{"read", "write"},
+		TTLSeconds:       int64((5 * time.Minute).Seconds()),
+	}
+	payload, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/delegate", bytes.NewReader(payload))
+	recorder := httptest.NewRecorder()
+
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", recorder.Code)
+	}
+}
+
+func TestDelegateHandlerTTLExpansion(t *testing.T) {
+	store := keystore.NewMemoryKeyStore()
+	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
+	mux := http.NewServeMux()
+	RegisterIssuerRoutes(mux, store, cfg)
+
+	signer, _ := store.GetSigningKey(cfg.DefaultTenantID)
+	issuerDID, _ := domain.DIDFromPublicKey(signer.Public())
+	parentToken, _ := domain.IssueBasicCredential(issuerDID, "did:jwk:parent", signer, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+
+	body := DelegateRequest{
+		ParentCredential: parentToken,
+		DelegateDID:      "did:jwk:agent",
+		Scope:            []string{"read"},
+		TTLSeconds:       int64((10 * time.Minute).Seconds()),
+	}
+	payload, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/delegate", bytes.NewReader(payload))
 	recorder := httptest.NewRecorder()
 
 	mux.ServeHTTP(recorder, req)

--- a/internal/httpx/verifier_handlers.go
+++ b/internal/httpx/verifier_handlers.go
@@ -13,16 +13,19 @@ import (
 
 // VerifyRequest represents a verifier request payload.
 type VerifyRequest struct {
-	Credential       string `json:"credential"`
-	ExpectedAudience string `json:"expected_audience"`
+	Credential       string   `json:"credential"`
+	Credentials      []string `json:"credentials"`
+	ExpectedAudience string   `json:"expected_audience"`
 }
 
 // VerifyResponse represents the verifier response payload.
 type VerifyResponse struct {
-	Valid     bool      `json:"valid"`
-	Subject   string    `json:"subject"`
-	Issuer    string    `json:"issuer"`
-	ExpiresAt time.Time `json:"expires_at"`
+	Valid            bool      `json:"valid"`
+	Subject          string    `json:"subject"`
+	Issuer           string    `json:"issuer"`
+	ExpiresAt        time.Time `json:"expires_at"`
+	ActingOnBehalfOf string    `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int       `json:"delegation_depth"`
 }
 
 // RegisterVerifierRoutes wires verifier HTTP routes into the provided mux.
@@ -43,7 +46,12 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			return
 		}
 
-		if req.Credential == "" {
+		tokens := req.Credentials
+		if len(tokens) == 0 && req.Credential != "" {
+			tokens = []string{req.Credential}
+		}
+
+		if len(tokens) == 0 {
 			WriteError(w, http.StatusBadRequest, "invalid_request", "credential is required")
 			return
 		}
@@ -58,7 +66,7 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			return resolver(issuer)
 		}}
 
-		result, err := domain.VerifyCredential(req.Credential, deps, req.ExpectedAudience, now())
+		chainResult, err := domain.VerifyCredentialChain(tokens, deps, domain.VerificationOptions{ExpectedAudience: req.ExpectedAudience, MaxDelegationDepth: 3}, now())
 		if err != nil {
 			switch {
 			case errors.Is(err, domain.ErrUntrustedIssuer):
@@ -71,12 +79,20 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			return
 		}
 
+		leaf := chainResult.Credentials[len(chainResult.Credentials)-1]
+		actingOnBehalfOf := leaf.Subject
+		if chainResult.DelegationDepth > 0 {
+			actingOnBehalfOf = chainResult.RootDelegator
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(VerifyResponse{
-			Valid:     true,
-			Subject:   result.Credential.Subject,
-			Issuer:    result.Credential.Issuer,
-			ExpiresAt: result.Credential.ExpiresAt,
+			Valid:            true,
+			Subject:          leaf.Subject,
+			Issuer:           leaf.Issuer,
+			ExpiresAt:        leaf.ExpiresAt,
+			ActingOnBehalfOf: actingOnBehalfOf,
+			DelegationDepth:  chainResult.DelegationDepth,
 		})
 	})
 }

--- a/internal/httpx/verifier_handlers_test.go
+++ b/internal/httpx/verifier_handlers_test.go
@@ -57,6 +57,59 @@ func TestVerifierHandlerSuccess(t *testing.T) {
 	if !resp.Valid || resp.Subject != "did:jwk:subject" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
+
+	if resp.DelegationDepth != 0 || resp.ActingOnBehalfOf != resp.Subject {
+		t.Fatalf("expected delegation metadata to mirror subject, got %+v", resp)
+	}
+}
+
+func TestVerifierHandlerDelegatedCredential(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+	registry := domain.NewMemoryTrustRegistry()
+	registry.AddTrustedIssuer("tenant", issuerDID)
+
+	resolver := func(issuer string) (crypto.PublicKey, error) {
+		if issuer != issuerDID {
+			return nil, domain.ErrUntrustedIssuer
+		}
+		return priv.Public(), nil
+	}
+
+	parent, err := domain.IssueBasicCredential(issuerDID, "did:jwk:parent", priv, 10*time.Minute, map[string]interface{}{"scope": []string{"read", "write"}})
+	if err != nil {
+		t.Fatalf("issue parent: %v", err)
+	}
+
+	child, err := domain.IssueBasicCredential(issuerDID, "did:jwk:agent", priv, 5*time.Minute, map[string]interface{}{"scope": []string{"read"}})
+	if err != nil {
+		t.Fatalf("issue child: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterVerifierRoutes(mux, resolver, registry, "tenant", time.Now)
+
+	reqPayload := VerifyRequest{Credentials: []string{parent, child}}
+	body, _ := json.Marshal(reqPayload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/verify", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp VerifyResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Subject != "did:jwk:agent" || resp.ActingOnBehalfOf != "did:jwk:parent" || resp.DelegationDepth != 1 {
+		t.Fatalf("unexpected delegation response: %+v", resp)
+	}
 }
 
 func TestVerifierHandlerExpiredCredential(t *testing.T) {

--- a/test/integration/delegation_integration_test.go
+++ b/test/integration/delegation_integration_test.go
@@ -1,0 +1,120 @@
+package integration
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/config"
+	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/httpx"
+	"github.com/bradtumy/credential-service/internal/keystore"
+)
+
+func TestDelegationIntegration(t *testing.T) {
+	store := keystore.NewMemoryKeyStore()
+	issuerCfg := config.LoadIssuerConfigFromEnv()
+	verifierCfg := config.LoadVerifierConfigFromEnv()
+
+	signer, err := store.GetSigningKey(issuerCfg.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("get signing key: %v", err)
+	}
+	issuerDID, err := domain.DIDFromPublicKey(signer.Public())
+	if err != nil {
+		t.Fatalf("derive issuer did: %v", err)
+	}
+
+	// Issuer server
+	issuerMux := http.NewServeMux()
+	httpx.RegisterIssuerRoutes(issuerMux, store, issuerCfg)
+	issuerServer := httptest.NewServer(issuerMux)
+	t.Cleanup(issuerServer.Close)
+
+	// Verifier server
+	registry := domain.NewMemoryTrustRegistry()
+	registry.AddTrustedIssuer(verifierCfg.DefaultTenantID, issuerDID)
+	resolver := func(issuer string) (crypto.PublicKey, error) {
+		if issuer != issuerDID {
+			return nil, domain.ErrUntrustedIssuer
+		}
+		return signer.Public(), nil
+	}
+
+	verifierMux := http.NewServeMux()
+	httpx.RegisterVerifierRoutes(verifierMux, resolver, registry, verifierCfg.DefaultTenantID, time.Now)
+	verifierServer := httptest.NewServer(verifierMux)
+	t.Cleanup(verifierServer.Close)
+
+	issueBody := httpx.IssueRequest{
+		SubjectDID: "did:jwk:owner",
+		TTLSeconds: int64((10 * time.Minute).Seconds()),
+		Claims:     map[string]interface{}{"scope": []string{"read", "write"}},
+	}
+	issuePayload, _ := json.Marshal(issueBody)
+	issueResp, err := http.Post(issuerServer.URL+"/v1/credentials/issue", "application/json", bytes.NewReader(issuePayload))
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = issueResp.Body.Close()
+	})
+	if issueResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from issuer, got %d", issueResp.StatusCode)
+	}
+	var issued httpx.IssueResponse
+	if err := json.NewDecoder(issueResp.Body).Decode(&issued); err != nil {
+		t.Fatalf("decode issue response: %v", err)
+	}
+
+	delegateReq := httpx.DelegateRequest{
+		ParentCredential: issued.Credential,
+		DelegateDID:      "did:jwk:agent",
+		Scope:            []string{"read"},
+		TTLSeconds:       int64((5 * time.Minute).Seconds()),
+	}
+	delegatePayload, _ := json.Marshal(delegateReq)
+	delegateResp, err := http.Post(issuerServer.URL+"/v1/credentials/delegate", "application/json", bytes.NewReader(delegatePayload))
+	if err != nil {
+		t.Fatalf("delegate credential: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = delegateResp.Body.Close()
+	})
+	if delegateResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from delegate, got %d", delegateResp.StatusCode)
+	}
+	var delegated httpx.IssueResponse
+	if err := json.NewDecoder(delegateResp.Body).Decode(&delegated); err != nil {
+		t.Fatalf("decode delegate response: %v", err)
+	}
+
+	verifyReq := httpx.VerifyRequest{Credentials: []string{issued.Credential, delegated.Credential}}
+	verifyPayload, _ := json.Marshal(verifyReq)
+	verifyResp, err := http.Post(verifierServer.URL+"/v1/credentials/verify", "application/json", bytes.NewReader(verifyPayload))
+	if err != nil {
+		t.Fatalf("verify credential: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = verifyResp.Body.Close()
+	})
+	if verifyResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from verifier, got %d", verifyResp.StatusCode)
+	}
+
+	var verifyBody httpx.VerifyResponse
+	if err := json.NewDecoder(verifyResp.Body).Decode(&verifyBody); err != nil {
+		t.Fatalf("decode verify response: %v", err)
+	}
+
+	if !verifyBody.Valid {
+		t.Fatalf("expected valid verification")
+	}
+	if verifyBody.Subject != "did:jwk:agent" || verifyBody.ActingOnBehalfOf != "did:jwk:owner" || verifyBody.DelegationDepth != 1 {
+		t.Fatalf("unexpected verification response: %+v", verifyBody)
+	}
+}


### PR DESCRIPTION
## Summary
- add delegation domain model helpers and chain-aware verification with scope, TTL, and depth enforcement
- expose issuer delegation endpoint and surface acting_on_behalf_of metadata in verifier responses
- cover delegation flows with unit and integration tests and update architecture docs

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692afaf7dd1c832c801bea3f6b708f10)