### PR TITLE
Add gateway authorization bridge and service-to-service sample

### DIFF
--- a/GATEWAY_INTEGRATION.md
+++ b/GATEWAY_INTEGRATION.md
@@ -1,0 +1,12 @@
+# Gateway & Legacy Integration
+
+Gateways or reverse proxies (Envoy, NGINX, API gateways) can call the verifier service to authorize requests that present verifiable credentials.
+
+## How it works
+
+- Gateways POST to `/v1/gateway/authorize` with the credential (or delegation chain) and optional expected audience.
+- The platform verifies the VC/delegation chain using the trust registry and issuer keys.
+- The endpoint returns an allow/deny decision with subject, acting-on-behalf-of, delegation depth, and the claims extracted from the credential.
+- When requested, the verifier can mint a synthetic JWT so downstream services can keep using `Authorization: Bearer <token>` without understanding VCs.
+
+This approach lets existing applications continue to rely on JWT-style headers while enforcing decentralized identity at the edge.

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, signer, issuerDID, time.Now)
 
 	log.Printf("Verifier service running on port %s...", cfg.HTTPPort)
 	log.Fatal(http.ListenAndServe(":"+cfg.HTTPPort, mux))

--- a/internal/domain/authz_bridge.go
+++ b/internal/domain/authz_bridge.go
@@ -1,0 +1,160 @@
+package domain
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// AuthzDecision captures an authorization decision derived from a verified credential chain.
+type AuthzDecision struct {
+	Allowed          bool                   `json:"allowed"`
+	SubjectDID       string                 `json:"subject"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	Reason           string                 `json:"reason,omitempty"`
+}
+
+// SyntheticJWT represents a minimal JWT-like structure for legacy services.
+type SyntheticJWT struct {
+	Token string `json:"token"`
+}
+
+// BuildAuthzDecisionFromVerification reshapes a DelegationChainResult into an AuthzDecision.
+func BuildAuthzDecisionFromVerification(result *DelegationChainResult) AuthzDecision {
+	decision := AuthzDecision{}
+	if result == nil || len(result.Credentials) == 0 {
+		decision.Reason = "missing_verification_result"
+		return decision
+	}
+
+	leaf := result.Credentials[len(result.Credentials)-1]
+	decision.Allowed = true
+	decision.SubjectDID = result.CurrentSubject
+	decision.ActingOnBehalfOf = result.RootDelegator
+	decision.DelegationDepth = result.DelegationDepth
+	decision.Claims = leaf.Claims
+
+	return decision
+}
+
+// BuildSyntheticJWT issues a compact JWT-like token from an authorization decision.
+func BuildSyntheticJWT(decision AuthzDecision, signingKey crypto.Signer, issuer string, ttl time.Duration) (SyntheticJWT, error) {
+	if !decision.Allowed {
+		return SyntheticJWT{}, fmt.Errorf("cannot mint token for denied decision")
+	}
+	if signingKey == nil {
+		return SyntheticJWT{}, fmt.Errorf("signing key is required")
+	}
+	if issuer == "" {
+		return SyntheticJWT{}, fmt.Errorf("issuer is required")
+	}
+	if ttl <= 0 {
+		return SyntheticJWT{}, fmt.Errorf("ttl must be positive")
+	}
+
+	now := time.Now().UTC()
+	payload := map[string]interface{}{
+		"iss":              issuer,
+		"sub":              decision.SubjectDID,
+		"iat":              now.Unix(),
+		"exp":              now.Add(ttl).Unix(),
+		"delegation_depth": decision.DelegationDepth,
+	}
+
+	if decision.ActingOnBehalfOf != "" {
+		payload["obo"] = decision.ActingOnBehalfOf
+	}
+
+	if scopeVal, ok := decision.Claims["scope"]; ok {
+		payload["scope"] = scopeVal
+	}
+
+	header := map[string]string{
+		"alg": "EdDSA",
+		"typ": "JWT",
+	}
+
+	headerSegment, err := encodeSegment(header)
+	if err != nil {
+		return SyntheticJWT{}, err
+	}
+
+	payloadSegment, err := encodeSegment(payload)
+	if err != nil {
+		return SyntheticJWT{}, err
+	}
+
+	signingInput := headerSegment + "." + payloadSegment
+
+	signature, err := signingKey.Sign(rand.Reader, []byte(signingInput), crypto.Hash(0))
+	if err != nil {
+		return SyntheticJWT{}, fmt.Errorf("sign payload: %w", err)
+	}
+
+	sigSegment := base64.RawURLEncoding.EncodeToString(signature)
+
+	return SyntheticJWT{Token: signingInput + "." + sigSegment}, nil
+}
+
+// DecodeSyntheticJWT is a helper used in tests to decode a synthetic JWT payload.
+func DecodeSyntheticJWT(token string) (map[string]interface{}, error) {
+	parts := splitToken(token)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal payload: %w", err)
+	}
+	return payload, nil
+}
+
+// VerifySyntheticJWTSignature verifies the EdDSA signature on a synthetic JWT.
+func VerifySyntheticJWTSignature(token string, publicKey crypto.PublicKey) error {
+	parts := splitToken(token)
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid token format")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+
+	edKey, ok := publicKey.(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("unsupported public key type")
+	}
+
+	if !ed25519.Verify(edKey, []byte(signingInput), signature) {
+		return fmt.Errorf("invalid signature")
+	}
+	return nil
+}
+
+func splitToken(token string) []string {
+	res := make([]string, 0, 3)
+	start := 0
+	for i := 0; i < len(token); i++ {
+		if token[i] == '.' {
+			res = append(res, token[start:i])
+			start = i + 1
+		}
+	}
+	if start <= len(token) {
+		res = append(res, token[start:])
+	}
+	return res
+}

--- a/internal/domain/authz_bridge_test.go
+++ b/internal/domain/authz_bridge_test.go
@@ -1,0 +1,81 @@
+package domain
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+)
+
+func TestBuildAuthzDecisionFromVerification(t *testing.T) {
+	credential := VerifiableCredential{
+		Subject: "did:example:alice",
+		Claims: map[string]interface{}{
+			"scope": []string{"read:orders"},
+		},
+	}
+
+	result := &DelegationChainResult{
+		Credentials:     []VerifiableCredential{credential},
+		CurrentSubject:  credential.Subject,
+		RootDelegator:   "did:example:alice",
+		DelegationDepth: 0,
+	}
+
+	decision := BuildAuthzDecisionFromVerification(result)
+
+	if !decision.Allowed || decision.SubjectDID != credential.Subject || decision.ActingOnBehalfOf != result.RootDelegator {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+
+	if scope := ScopeFromClaims(decision.Claims); len(scope) != 1 || scope[0] != "read:orders" {
+		t.Fatalf("claims not propagated: %+v", decision.Claims)
+	}
+}
+
+func TestBuildSyntheticJWT(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+
+	decision := AuthzDecision{
+		Allowed:          true,
+		SubjectDID:       "did:example:carol",
+		ActingOnBehalfOf: "did:example:root",
+		DelegationDepth:  1,
+		Claims: map[string]interface{}{
+			"scope": "read:orders",
+		},
+	}
+
+	token, err := BuildSyntheticJWT(decision, priv, "did:issuer:verifier", time.Minute)
+	if err != nil {
+		t.Fatalf("build synthetic jwt: %v", err)
+	}
+
+	if token.Token == "" {
+		t.Fatalf("expected token to be populated")
+	}
+
+	if err := VerifySyntheticJWTSignature(token.Token, priv.Public()); err != nil {
+		t.Fatalf("verify signature: %v", err)
+	}
+
+	payload, err := DecodeSyntheticJWT(token.Token)
+	if err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+
+	if payload["sub"] != decision.SubjectDID {
+		t.Fatalf("expected sub %s, got %v", decision.SubjectDID, payload["sub"])
+	}
+
+	if payload["obo"] != decision.ActingOnBehalfOf {
+		t.Fatalf("expected obo %s, got %v", decision.ActingOnBehalfOf, payload["obo"])
+	}
+
+	if payload["delegation_depth"] != float64(decision.DelegationDepth) {
+		t.Fatalf("unexpected delegation depth: %v", payload["delegation_depth"])
+	}
+
+	if payload["scope"] != "read:orders" {
+		t.Fatalf("unexpected scope: %v", payload["scope"])
+	}
+}

--- a/internal/httpx/gateway_handlers.go
+++ b/internal/httpx/gateway_handlers.go
@@ -1,0 +1,131 @@
+package httpx
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+// GatewayAuthorizeRequest is the payload expected by the gateway authorize endpoint.
+type GatewayAuthorizeRequest struct {
+	Credential       string   `json:"credential"`
+	Credentials      []string `json:"credentials"`
+	ExpectedAudience string   `json:"expected_audience"`
+	WantSyntheticJWT bool     `json:"want_synthetic_jwt"`
+}
+
+// GatewayAuthorizeResponse is returned to gateways or reverse proxies.
+type GatewayAuthorizeResponse struct {
+	Allowed          bool                   `json:"allowed"`
+	Subject          string                 `json:"subject,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	Reason           string                 `json:"reason,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+}
+
+// RegisterGatewayRoutes wires gateway-specific routes into the provided mux.
+func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, tenantID string, signingKey crypto.Signer, jwtIssuer string, now func() time.Time) {
+	if now == nil {
+		now = time.Now
+	}
+
+	mux.HandleFunc("/v1/gateway/authorize", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			WriteError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+
+		var req GatewayAuthorizeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			WriteError(w, http.StatusBadRequest, "bad_request", "invalid request payload")
+			return
+		}
+
+		tokens := req.Credentials
+		if len(tokens) == 0 && req.Credential != "" {
+			tokens = []string{req.Credential}
+		}
+
+		if len(tokens) == 0 {
+			WriteError(w, http.StatusBadRequest, "invalid_request", "credential is required")
+			return
+		}
+
+		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
+			if registry != nil && !registry.IsTrustedIssuer(tenantID, issuer) {
+				return nil, domain.ErrUntrustedIssuer
+			}
+			if resolver == nil {
+				return nil, fmt.Errorf("resolver not configured")
+			}
+			return resolver(issuer)
+		}}
+
+		chainResult, err := domain.VerifyCredentialChain(tokens, deps, domain.VerificationOptions{ExpectedAudience: req.ExpectedAudience, MaxDelegationDepth: 3}, now())
+		if err != nil {
+			reason := mapVerificationErrorToReason(err)
+			writeDecision(w, GatewayAuthorizeResponse{Allowed: false, Reason: reason})
+			return
+		}
+
+		decision := domain.BuildAuthzDecisionFromVerification(chainResult)
+
+		response := GatewayAuthorizeResponse{
+			Allowed:          decision.Allowed,
+			Subject:          decision.SubjectDID,
+			ActingOnBehalfOf: decision.ActingOnBehalfOf,
+			DelegationDepth:  decision.DelegationDepth,
+			Claims:           decision.Claims,
+			Reason:           decision.Reason,
+		}
+
+		if req.WantSyntheticJWT {
+			jwt, err := domain.BuildSyntheticJWT(decision, signingKey, jwtIssuer, 15*time.Minute)
+			if err != nil {
+				writeDecision(w, GatewayAuthorizeResponse{Allowed: false, Reason: "jwt_error"})
+				return
+			}
+			response.SyntheticJWT = jwt.Token
+		}
+
+		writeDecision(w, response)
+	})
+}
+
+func writeDecision(w http.ResponseWriter, resp GatewayAuthorizeResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	status := http.StatusOK
+	if !resp.Allowed {
+		status = http.StatusForbidden
+	}
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func mapVerificationErrorToReason(err error) string {
+	switch {
+	case errors.Is(err, domain.ErrExpiredCredential):
+		return "expired_credential"
+	case errors.Is(err, domain.ErrUntrustedIssuer):
+		return "untrusted_issuer"
+	case errors.Is(err, domain.ErrInvalidSignature):
+		return "invalid_signature"
+	case errors.Is(err, domain.ErrUnexpectedAudience):
+		return "unexpected_audience"
+	case errors.Is(err, domain.ErrDelegationDepth):
+		return "delegation_depth_exceeded"
+	case errors.Is(err, domain.ErrDelegationScope):
+		return "invalid_scope"
+	case errors.Is(err, domain.ErrDelegationTTL):
+		return "invalid_ttl"
+	default:
+		return "verification_failed"
+	}
+}

--- a/internal/httpx/gateway_handlers_test.go
+++ b/internal/httpx/gateway_handlers_test.go
@@ -1,0 +1,141 @@
+package httpx
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+func TestGatewayAuthorizeAllow(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+	registry := domain.NewMemoryTrustRegistry()
+	registry.AddTrustedIssuer("tenant", issuerDID)
+
+	resolver := func(issuer string) (crypto.PublicKey, error) {
+		if issuer != issuerDID {
+			return nil, domain.ErrUntrustedIssuer
+		}
+		return priv.Public(), nil
+	}
+
+	token, err := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 5*time.Minute, map[string]interface{}{"scope": "read:orders"})
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, time.Now)
+
+	payload := GatewayAuthorizeRequest{Credential: token, WantSyntheticJWT: true}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var resp GatewayAuthorizeResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !resp.Allowed || resp.Subject != "did:example:agent" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	if resp.SyntheticJWT == "" {
+		t.Fatalf("expected synthetic jwt to be present")
+	}
+}
+
+func TestGatewayAuthorizeDenyExpired(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+	registry := domain.NewMemoryTrustRegistry()
+	registry.AddTrustedIssuer("tenant", issuerDID)
+
+	resolver := func(string) (crypto.PublicKey, error) {
+		return priv.Public(), nil
+	}
+
+	token, err := domain.IssueBasicCredential(issuerDID, "did:example:bob", priv, time.Minute, nil)
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	cred := decodeCredentialForHandlerTest(t, token)
+
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, func() time.Time {
+		return cred.ExpiresAt.Add(time.Second)
+	})
+
+	payload := GatewayAuthorizeRequest{Credential: token}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+
+	var resp GatewayAuthorizeResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp.Allowed || resp.Reason != "expired_credential" {
+		t.Fatalf("unexpected deny response: %+v", resp)
+	}
+}
+
+func TestGatewayAuthorizeUntrustedIssuer(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+	registry := domain.NewMemoryTrustRegistry()
+	resolver := func(string) (crypto.PublicKey, error) {
+		return priv.Public(), nil
+	}
+
+	token, err := domain.IssueBasicCredential(issuerDID, "did:example:bob", priv, 5*time.Minute, nil)
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, time.Now)
+
+	payload := GatewayAuthorizeRequest{Credential: token}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+
+	var resp GatewayAuthorizeResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Allowed || resp.Reason != "untrusted_issuer" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/samples/s2s/README.md
+++ b/samples/s2s/README.md
@@ -1,0 +1,43 @@
+# Service-to-Service Sample
+
+This sample demonstrates how an issuer, gateway authorization endpoint, and a legacy-style API can work together. The flow turns a verifiable credential into a synthetic JWT that a typical service can accept without understanding VCs.
+
+## Components
+
+- **client-service**: requests a VC from the issuer, calls the gateway authorize endpoint to obtain a decision + synthetic JWT, then calls the API service with `Authorization: Bearer <token>`.
+- **api-service**: represents a legacy API. It accepts the synthetic JWT, decodes it, logs the claims, and responds with a simple JSON payload.
+
+## Running the sample
+
+1. Start the issuer and verifier services (from the repository root):
+
+   ```bash
+   go run ./cmd/issuer &
+   go run ./cmd/verifier &
+   ```
+
+2. Start the API service:
+
+   ```bash
+   go run ./samples/s2s/api-service
+   ```
+
+3. Start the client service (it will call the issuer, gateway, then API):
+
+   ```bash
+   go run ./samples/s2s/client-service
+   ```
+
+Environment variables:
+
+- `ISSUER_URL` (default `http://localhost:8080`)
+- `GATEWAY_URL` (default `http://localhost:8081`)
+- `API_URL` (default `http://localhost:8082`)
+
+## Request flow
+
+1. Client requests a verifiable credential from the issuer with desired claims/scopes.
+2. Client presents the credential to `/v1/gateway/authorize` on the verifier service.
+3. Gateway endpoint verifies the VC (and any delegation), returns an allow/deny decision and optionally a synthetic JWT.
+4. Client calls the API with `Authorization: Bearer <synthetic_jwt>`.
+5. The API trusts the JWT and logs claims without needing to parse verifiable credentials.

--- a/samples/s2s/api-service/main.go
+++ b/samples/s2s/api-service/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+type response struct {
+	OK      bool                   `json:"ok"`
+	Subject string                 `json:"subject"`
+	Claims  map[string]interface{} `json:"claims"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/orders", func(w http.ResponseWriter, r *http.Request) {
+		authz := r.Header.Get("Authorization")
+		if authz == "" || !strings.HasPrefix(authz, "Bearer ") {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"missing_token"}`))
+			return
+		}
+
+		token := strings.TrimPrefix(authz, "Bearer ")
+
+		payload, err := domain.DecodeSyntheticJWT(token)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_token"}`))
+			return
+		}
+
+		subject, _ := payload["sub"].(string)
+
+		log.Printf("api-service received request from subject %s with claims %v", subject, payload)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response{OK: true, Subject: subject, Claims: payload})
+	})
+
+	log.Printf("api-service listening on :8082")
+	log.Fatal(http.ListenAndServe(":8082", mux))
+}

--- a/samples/s2s/client-service/main.go
+++ b/samples/s2s/client-service/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+)
+
+type issueResponse struct {
+	Credential string `json:"credential"`
+}
+
+type gatewayAuthzResponse struct {
+	Allowed      bool                   `json:"allowed"`
+	Subject      string                 `json:"subject"`
+	Claims       map[string]interface{} `json:"claims"`
+	SyntheticJWT string                 `json:"synthetic_jwt"`
+	Reason       string                 `json:"reason"`
+}
+
+func main() {
+	issuerURL := envOrDefault("ISSUER_URL", "http://localhost:8080")
+	gatewayURL := envOrDefault("GATEWAY_URL", "http://localhost:8081")
+	apiURL := envOrDefault("API_URL", "http://localhost:8082")
+
+	credential, err := issueCredential(issuerURL)
+	if err != nil {
+		log.Fatalf("issue credential: %v", err)
+	}
+	log.Printf("issued credential: %s", credential)
+
+	decision, err := authorizeWithGateway(gatewayURL, credential)
+	if err != nil {
+		log.Fatalf("authorize: %v", err)
+	}
+
+	if !decision.Allowed {
+		log.Fatalf("gateway denied request: %s", decision.Reason)
+	}
+
+	log.Printf("gateway authorized subject %s with claims %v", decision.Subject, decision.Claims)
+
+	if decision.SyntheticJWT == "" {
+		log.Fatalf("gateway did not return a synthetic jwt")
+	}
+
+	if err := callAPI(apiURL, decision.SyntheticJWT); err != nil {
+		log.Fatalf("call api: %v", err)
+	}
+
+	log.Printf("client-service completed successfully")
+}
+
+func issueCredential(baseURL string) (string, error) {
+	payload := map[string]interface{}{
+		"subject_did": "did:example:client",
+		"ttl_seconds": 300,
+		"claims": map[string]interface{}{
+			"scope": "read:orders",
+			"aud":   "sample-api",
+		},
+	}
+
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(baseURL+"/v1/credentials/issue", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(data))
+	}
+
+	var parsed issueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return "", err
+	}
+	return parsed.Credential, nil
+}
+
+func authorizeWithGateway(baseURL, credential string) (gatewayAuthzResponse, error) {
+	payload := map[string]interface{}{
+		"credential":         credential,
+		"expected_audience":  "sample-api",
+		"want_synthetic_jwt": true,
+	}
+	body, _ := json.Marshal(payload)
+
+	resp, err := http.Post(baseURL+"/v1/gateway/authorize", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return gatewayAuthzResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	var parsed gatewayAuthzResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return gatewayAuthzResponse{}, err
+	}
+	return parsed, nil
+}
+
+func callAPI(baseURL, token string) error {
+	req, _ := http.NewRequest(http.MethodGet, baseURL+"/orders", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("api returned %d: %s", resp.StatusCode, string(data))
+	}
+
+	log.Printf("api response: %s", string(data))
+	return nil
+}
+
+func envOrDefault(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary
- add domain bridge to produce authorization decisions and synthetic JWTs
- expose gateway-friendly /v1/gateway/authorize endpoint on verifier service
- provide service-to-service sample demonstrating gateway authorize flow and document gateway integration

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692affd8f38c832ca066afd775342d99)