### PR TITLE
Add Postgres trust registry, logging, metrics, and security docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,16 +9,23 @@ The credential-service repository now follows an idiomatic Go layout that separa
 ## Internal Modules
 - `internal/domain`: core verifiable credential types, issuance helpers, and multi-tenant context primitives.
 - `internal/httpx`: HTTP helpers for error responses and middleware (request/tenant IDs).
+- `internal/logging`: structured logging setup shared by binaries.
+- `internal/metrics`: stubs for verifier metrics instrumentation.
 - `internal/config`: lightweight environment-based configuration loader.
 - `internal/keystore`: abstraction for retrieving signing keys for tenants.
 - `internal/issuer`: issuer-specific routing, queueing, and issuance orchestration.
 - `internal/verifier`: verification handlers that wrap domain validation.
+- `internal/storage`: storage helpers including the Postgres-backed trust registry.
 
 ## Data Flow (simplified)
 1. **Issue**: HTTP request hits `cmd/issuer` → router (`internal/issuer`) → credential built/signature attached (`internal/domain`) → stored (PostgreSQL) and queued (RabbitMQ).
 2. **Store/Queue**: Credentials persisted via `pgx` (if configured) and issuance jobs emitted to RabbitMQ for background processing.
 3. **Verify**: Presentation posted to `cmd/verifier` → handler (`internal/verifier`) → validation rules in `internal/domain`.
 4. **Future**: Trust registry and delegation rules will extend `internal/domain` and share middleware/config utilities.
+
+## Trust Registry Storage
+- A Postgres-backed trust registry is available via `internal/storage.PGTrustRegistry`.
+- Deployments using Postgres must create the `trusted_issuers` table (see `migrations/0001_create_trusted_issuers.sql`).
 
 ## Delegation and Agent Identity
 - Credentials can be delegated from one DID to another, enabling agents to act with constrained authority.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,8 @@
 # Security Guidelines
 
-- **Secrets**: Never commit secrets or private keys. Fetch signing keys from Vault/KMS and keep them per-tenant.
-- **Multi-tenancy**: Tenant context is carried via middleware; every new handler must respect tenant isolation.
-- **Delegation**: Future delegation features must never increase privilege beyond the parent scope.
+- **Secrets**: Never commit secrets or private keys. The current development setup uses in-memory keys only; production deployments must fetch and protect signing keys with a KMS/HSM and avoid persisting private keys to disk or databases.
+- **Multi-tenancy**: Tenant context is carried via middleware; every handler must enforce tenant isolation. Trust registry entries are per-tenant and should never be shared across tenants.
+- **Delegation safety**: Delegated credentials must always shrink scope and TTL, and the verifier enforces a maximum delegation depth. Extending delegation logic must preserve these constraints.
 - **Transport**: Use TLS-terminated endpoints in production and prefer mTLS for service-to-service communication.
 - **Dependency Scanning**: `make sec` runs gosec for quick checks; CI enforces this alongside linting.
+- **Threat model**: See `THREAT_MODEL.md` for a concise analysis of assets, threats, and planned mitigations.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,46 @@
+# Threat Model
+
+## Overview
+The credential-service issues and verifies verifiable credentials for multiple tenants. Core components include the issuer service, verifier service, trust registry (now backed by Postgres), and a gateway authorize endpoint that bridges VC verification into authorization decisions/JWTs.
+
+## Assets
+- Issuer signing keys
+- Credentials / verifiable credentials (VCs)
+- Delegation chains and acting_on_behalf_of relationships
+- Trust registry data (per-tenant issuer trust)
+- Logs and audit trails
+
+## Actors
+- Legitimate users, services, and agents presenting credentials
+- Tenant administrators managing trusted issuers
+- External attackers attempting forgery or abuse
+- Malicious tenants attempting cross-tenant access
+- Compromised internal components or infrastructure
+
+## Trust Boundaries
+- Internet clients to issuer/verifier HTTP services
+- Services to the Postgres database that stores trust registry entries
+- Services to external or future key management systems (KMS/HSM)
+- Gateway/service-to-service calls carrying delegated credentials
+
+## Threats (STRIDE)
+- **Spoofing**: Fake issuers or agents presenting forged credentials
+- **Tampering**: Manipulating credential payloads, delegation chains, or logs
+- **Repudiation**: Denial of issued or verified actions without auditability
+- **Information Disclosure**: Leakage of credentials, keys, or tenant metadata
+- **Denial of Service**: Flooding verifier/issuer endpoints or database dependencies
+- **Elevation of Privilege**: Delegation misuse or cross-tenant trust leakage
+
+## Mitigations (Current State)
+- Signature verification and DID binding for every credential
+- Delegation rules enforce reduced scope/TTL and maximum depth
+- Trust registry with per-tenant entries (memory or Postgres-backed storage)
+- Structured HTTP request logs that include request/tenant IDs and status
+- Verification responses report explicit failure reasons
+- Automated tests covering invalid chains, expired credentials, and untrusted issuers
+
+## Open Questions / Future Work
+- Use of KMS/HSM for protecting issuer keys
+- Rate limiting and DoS protections at the edge
+- Integrity protections for audit logs (e.g., signing logs or shipping to WORM storage)
+- Formal penetration testing and cryptography reviews

--- a/cmd/issuer/main.go
+++ b/cmd/issuer/main.go
@@ -7,17 +7,21 @@ import (
 	"github.com/bradtumy/credential-service/internal/config"
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
+	"github.com/bradtumy/credential-service/internal/logging"
 )
 
 func main() {
 	cfg := config.LoadIssuerConfigFromEnv()
+	logging.Init(cfg.LogLevel)
 	store := keystore.NewMemoryKeyStore()
 
 	mux := http.NewServeMux()
 	httpx.RegisterIssuerRoutes(mux, store, cfg)
 
+	handler := httpx.RequestContext(httpx.LoggingMiddleware(mux))
+
 	log.Printf("Issuer service running on port %s", cfg.HTTPPort)
-	if err := http.ListenAndServe(":"+cfg.HTTPPort, mux); err != nil {
+	if err := http.ListenAndServe(":"+cfg.HTTPPort, handler); err != nil {
 		log.Fatalf("failed to start server: %v", err)
 	}
 }

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -1,22 +1,38 @@
 package main
 
 import (
+	"context"
 	"crypto"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
 	"time"
 
+	_ "github.com/lib/pq"
+
 	"github.com/bradtumy/credential-service/internal/config"
 	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
+	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/storage"
 )
 
 func main() {
 	cfg := config.LoadVerifierConfigFromEnv()
+	logging.Init(cfg.LogLevel)
 
-	trustRegistry := domain.NewMemoryTrustRegistry()
+	var trustRegistry domain.TrustRegistry = domain.NewMemoryTrustRegistry()
+
+	if cfg.UseDBTrustRegistry && cfg.DB_DSN != "" {
+		db, err := sql.Open("postgres", cfg.DB_DSN)
+		if err != nil {
+			log.Fatalf("connect to database: %v", err)
+		}
+		trustRegistry = storage.NewPGTrustRegistry(db)
+	}
+
 	issuerKeys := make(map[string]crypto.PublicKey)
 
 	store := keystore.NewMemoryKeyStore()
@@ -31,7 +47,9 @@ func main() {
 	}
 
 	issuerKeys[issuerDID] = signer.Public()
-	trustRegistry.AddTrustedIssuer(cfg.DefaultTenantID, issuerDID)
+	if err := trustRegistry.AddTrustedIssuer(context.Background(), cfg.DefaultTenantID, issuerDID); err != nil {
+		log.Fatalf("seed trust registry: %v", err)
+	}
 
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		key, ok := issuerKeys[issuer]
@@ -45,6 +63,8 @@ func main() {
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
 	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, signer, issuerDID, time.Now)
 
+	handler := httpx.RequestContext(httpx.LoggingMiddleware(mux))
+
 	log.Printf("Verifier service running on port %s...", cfg.HTTPPort)
-	log.Fatal(http.ListenAndServe(":"+cfg.HTTPPort, mux))
+	log.Fatal(http.ListenAndServe(":"+cfg.HTTPPort, handler))
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ func getenv(key, fallback string) string {
 type IssuerConfig struct {
 	HTTPPort        string
 	DefaultTenantID string
+	LogLevel        string
 }
 
 // LoadIssuerConfigFromEnv loads issuer configuration from environment variables.
@@ -48,19 +49,26 @@ func LoadIssuerConfigFromEnv() IssuerConfig {
 	return IssuerConfig{
 		HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
 		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
 	}
 }
 
 // VerifierConfig holds configuration for the verifier service.
 type VerifierConfig struct {
-	HTTPPort        string
-	DefaultTenantID string
+	HTTPPort           string
+	DefaultTenantID    string
+	DB_DSN             string
+	UseDBTrustRegistry bool
+	LogLevel           string
 }
 
 // LoadVerifierConfigFromEnv loads verifier configuration from environment variables.
 func LoadVerifierConfigFromEnv() VerifierConfig {
 	return VerifierConfig{
-		HTTPPort:        getenv("VERIFIER_HTTP_PORT", "8081"),
-		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
+		DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
+		UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
+		LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestLoadIssuerConfigFromEnvDefaults(t *testing.T) {
 	t.Setenv("ISSUER_HTTP_PORT", "")
 	t.Setenv("DEFAULT_TENANT_ID", "")
+	t.Setenv("ISSUER_LOG_LEVEL", "")
 
 	cfg := LoadIssuerConfigFromEnv()
 
@@ -14,11 +15,15 @@ func TestLoadIssuerConfigFromEnvDefaults(t *testing.T) {
 	if cfg.DefaultTenantID != "default-tenant" {
 		t.Fatalf("expected default tenant id, got %s", cfg.DefaultTenantID)
 	}
+	if cfg.LogLevel != "info" {
+		t.Fatalf("expected default log level info, got %s", cfg.LogLevel)
+	}
 }
 
 func TestLoadIssuerConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("ISSUER_HTTP_PORT", "9090")
 	t.Setenv("DEFAULT_TENANT_ID", "tenant-123")
+	t.Setenv("ISSUER_LOG_LEVEL", "debug")
 
 	cfg := LoadIssuerConfigFromEnv()
 
@@ -28,11 +33,17 @@ func TestLoadIssuerConfigFromEnvOverrides(t *testing.T) {
 	if cfg.DefaultTenantID != "tenant-123" {
 		t.Fatalf("expected tenant-123, got %s", cfg.DefaultTenantID)
 	}
+	if cfg.LogLevel != "debug" {
+		t.Fatalf("expected debug log level, got %s", cfg.LogLevel)
+	}
 }
 
 func TestLoadVerifierConfigFromEnvDefaults(t *testing.T) {
 	t.Setenv("VERIFIER_HTTP_PORT", "")
 	t.Setenv("DEFAULT_TENANT_ID", "")
+	t.Setenv("VERIFIER_DB_DSN", "")
+	t.Setenv("VERIFIER_USE_DB_TRUST_REGISTRY", "")
+	t.Setenv("VERIFIER_LOG_LEVEL", "")
 
 	cfg := LoadVerifierConfigFromEnv()
 
@@ -42,11 +53,23 @@ func TestLoadVerifierConfigFromEnvDefaults(t *testing.T) {
 	if cfg.DefaultTenantID != "default-tenant" {
 		t.Fatalf("expected default tenant id, got %s", cfg.DefaultTenantID)
 	}
+	if cfg.DB_DSN != "" {
+		t.Fatalf("expected empty DB DSN, got %s", cfg.DB_DSN)
+	}
+	if cfg.UseDBTrustRegistry {
+		t.Fatalf("expected DB trust registry disabled by default")
+	}
+	if cfg.LogLevel != "info" {
+		t.Fatalf("expected default log level info, got %s", cfg.LogLevel)
+	}
 }
 
 func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("VERIFIER_HTTP_PORT", "7070")
 	t.Setenv("DEFAULT_TENANT_ID", "tenant-verifier")
+	t.Setenv("VERIFIER_DB_DSN", "postgres://example")
+	t.Setenv("VERIFIER_USE_DB_TRUST_REGISTRY", "true")
+	t.Setenv("VERIFIER_LOG_LEVEL", "warn")
 
 	cfg := LoadVerifierConfigFromEnv()
 
@@ -55,5 +78,14 @@ func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.DefaultTenantID != "tenant-verifier" {
 		t.Fatalf("expected tenant-verifier, got %s", cfg.DefaultTenantID)
+	}
+	if cfg.DB_DSN != "postgres://example" {
+		t.Fatalf("expected DSN override, got %s", cfg.DB_DSN)
+	}
+	if !cfg.UseDBTrustRegistry {
+		t.Fatalf("expected DB trust registry enabled")
+	}
+	if cfg.LogLevel != "warn" {
+		t.Fatalf("expected warn log level, got %s", cfg.LogLevel)
 	}
 }

--- a/internal/domain/trust_registry.go
+++ b/internal/domain/trust_registry.go
@@ -1,11 +1,15 @@
 package domain
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // TrustRegistry describes issuer trust lookups.
 type TrustRegistry interface {
-	IsTrustedIssuer(tenantID, issuerDID string) bool
-	AddTrustedIssuer(tenantID, issuerDID string)
+	IsTrustedIssuer(ctx context.Context, tenantID, issuerDID string) (bool, error)
+	AddTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error
+	RemoveTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error
 }
 
 // MemoryTrustRegistry provides an in-memory trust store.
@@ -20,21 +24,21 @@ func NewMemoryTrustRegistry() *MemoryTrustRegistry {
 }
 
 // IsTrustedIssuer checks whether an issuer is trusted for a tenant.
-func (m *MemoryTrustRegistry) IsTrustedIssuer(tenantID, issuerDID string) bool {
+func (m *MemoryTrustRegistry) IsTrustedIssuer(_ context.Context, tenantID, issuerDID string) (bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	issuers, ok := m.trusted[tenantID]
 	if !ok {
-		return false
+		return false, nil
 	}
 
 	_, trusted := issuers[issuerDID]
-	return trusted
+	return trusted, nil
 }
 
 // AddTrustedIssuer marks an issuer as trusted for a tenant.
-func (m *MemoryTrustRegistry) AddTrustedIssuer(tenantID, issuerDID string) {
+func (m *MemoryTrustRegistry) AddTrustedIssuer(_ context.Context, tenantID, issuerDID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -43,4 +47,19 @@ func (m *MemoryTrustRegistry) AddTrustedIssuer(tenantID, issuerDID string) {
 	}
 
 	m.trusted[tenantID][issuerDID] = struct{}{}
+	return nil
+}
+
+// RemoveTrustedIssuer deletes an issuer from the trust registry.
+func (m *MemoryTrustRegistry) RemoveTrustedIssuer(_ context.Context, tenantID, issuerDID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	issuers := m.trusted[tenantID]
+	if issuers == nil {
+		return nil
+	}
+
+	delete(issuers, issuerDID)
+	return nil
 }

--- a/internal/domain/trust_registry_test.go
+++ b/internal/domain/trust_registry_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestMemoryTrustRegistry(t *testing.T) {
 	registry := NewMemoryTrustRegistry()
@@ -9,17 +12,27 @@ func TestMemoryTrustRegistry(t *testing.T) {
 	tenantB := "tenant-b"
 	issuer := "did:jwk:issuer"
 
-	registry.AddTrustedIssuer(tenantA, issuer)
+	if err := registry.AddTrustedIssuer(context.Background(), tenantA, issuer); err != nil {
+		t.Fatalf("unexpected error adding issuer: %v", err)
+	}
 
-	if !registry.IsTrustedIssuer(tenantA, issuer) {
+	trusted, err := registry.IsTrustedIssuer(context.Background(), tenantA, issuer)
+	if err != nil {
+		t.Fatalf("unexpected error checking trust: %v", err)
+	}
+	if !trusted {
 		t.Fatalf("expected issuer to be trusted for tenantA")
 	}
 
-	if registry.IsTrustedIssuer(tenantB, issuer) {
+	if err := registry.RemoveTrustedIssuer(context.Background(), tenantB, issuer); err != nil {
+		t.Fatalf("unexpected error removing issuer for tenantB: %v", err)
+	}
+
+	if trusted, _ := registry.IsTrustedIssuer(context.Background(), tenantB, issuer); trusted {
 		t.Fatalf("issuer should not be trusted for tenantB")
 	}
 
-	if registry.IsTrustedIssuer(tenantA, "did:jwk:unknown") {
+	if trusted, _ := registry.IsTrustedIssuer(context.Background(), tenantA, "did:jwk:unknown"); trusted {
 		t.Fatalf("unexpected trust for unknown issuer")
 	}
 }

--- a/internal/httpx/gateway_handlers.go
+++ b/internal/httpx/gateway_handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/metrics"
 )
 
 // GatewayAuthorizeRequest is the payload expected by the gateway authorize endpoint.
@@ -59,8 +60,14 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		}
 
 		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
-			if registry != nil && !registry.IsTrustedIssuer(tenantID, issuer) {
-				return nil, domain.ErrUntrustedIssuer
+			if registry != nil {
+				trusted, err := registry.IsTrustedIssuer(r.Context(), tenantID, issuer)
+				if err != nil {
+					return nil, fmt.Errorf("trust lookup: %w", err)
+				}
+				if !trusted {
+					return nil, domain.ErrUntrustedIssuer
+				}
 			}
 			if resolver == nil {
 				return nil, fmt.Errorf("resolver not configured")
@@ -71,6 +78,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		chainResult, err := domain.VerifyCredentialChain(tokens, deps, domain.VerificationOptions{ExpectedAudience: req.ExpectedAudience, MaxDelegationDepth: 3}, now())
 		if err != nil {
 			reason := mapVerificationErrorToReason(err)
+			metrics.DefaultVerifierMetrics.IncVerificationFailure(reason)
 			writeDecision(w, GatewayAuthorizeResponse{Allowed: false, Reason: reason})
 			return
 		}
@@ -95,6 +103,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			response.SyntheticJWT = jwt.Token
 		}
 
+		metrics.DefaultVerifierMetrics.IncVerificationSuccess("ok")
 		writeDecision(w, response)
 	})
 }

--- a/internal/httpx/gateway_handlers_test.go
+++ b/internal/httpx/gateway_handlers_test.go
@@ -1,24 +1,25 @@
 package httpx
 
 import (
-	"bytes"
-	"crypto"
-	"crypto/ed25519"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+"bytes"
+"context"
+"crypto"
+"crypto/ed25519"
+"encoding/json"
+"net/http"
+"net/http/httptest"
+"testing"
+"time"
 
-	"github.com/bradtumy/credential-service/internal/domain"
+"github.com/bradtumy/credential-service/internal/domain"
 )
 
 func TestGatewayAuthorizeAllow(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
-	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer("tenant", issuerDID)
+registry := domain.NewMemoryTrustRegistry()
+registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
 
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		if issuer != issuerDID {
@@ -65,8 +66,8 @@ func TestGatewayAuthorizeDenyExpired(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
-	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer("tenant", issuerDID)
+registry := domain.NewMemoryTrustRegistry()
+registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
 
 	resolver := func(string) (crypto.PublicKey, error) {
 		return priv.Public(), nil

--- a/internal/httpx/middleware.go
+++ b/internal/httpx/middleware.go
@@ -3,8 +3,11 @@ package httpx
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/bradtumy/credential-service/internal/logging"
 )
 
 type contextKey string
@@ -49,4 +52,34 @@ func TenantIDFromContext(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(statusCode int) {
+	r.status = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}
+
+// LoggingMiddleware emits structured request logs for HTTP handlers.
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+
+		next.ServeHTTP(recorder, r)
+
+		duration := time.Since(start)
+		logging.Logger.Info("http_request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", recorder.status,
+			"duration_ms", duration.Milliseconds(),
+			"request_id", RequestIDFromContext(r.Context()),
+			"tenant_id", TenantIDFromContext(r.Context()),
+		)
+	})
 }

--- a/internal/httpx/middleware_test.go
+++ b/internal/httpx/middleware_test.go
@@ -1,9 +1,14 @@
 package httpx
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/bradtumy/credential-service/internal/logging"
 )
 
 func TestRequestContextAddsIDs(t *testing.T) {
@@ -36,4 +41,28 @@ func TestRequestContextUsesProvidedRequestID(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+}
+
+func TestLoggingMiddlewareInvokesNext(t *testing.T) {
+	called := false
+	logging.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	req = req.WithContext(context.WithValue(req.Context(), requestIDKey, "req-1"))
+	req = req.WithContext(context.WithValue(req.Context(), tenantIDKey, "tenant-1"))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if rr.Code != http.StatusTeapot {
+		t.Fatalf("expected status to propagate, got %d", rr.Code)
+	}
 }

--- a/internal/httpx/verifier_handlers.go
+++ b/internal/httpx/verifier_handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/metrics"
 )
 
 // VerifyRequest represents a verifier request payload.
@@ -57,8 +58,14 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 		}
 
 		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
-			if registry != nil && !registry.IsTrustedIssuer(tenantID, issuer) {
-				return nil, domain.ErrUntrustedIssuer
+			if registry != nil {
+				trusted, err := registry.IsTrustedIssuer(r.Context(), tenantID, issuer)
+				if err != nil {
+					return nil, fmt.Errorf("trust lookup: %w", err)
+				}
+				if !trusted {
+					return nil, domain.ErrUntrustedIssuer
+				}
 			}
 			if resolver == nil {
 				return nil, fmt.Errorf("resolver not configured")
@@ -68,14 +75,18 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 
 		chainResult, err := domain.VerifyCredentialChain(tokens, deps, domain.VerificationOptions{ExpectedAudience: req.ExpectedAudience, MaxDelegationDepth: 3}, now())
 		if err != nil {
+			reason := "verification_failed"
 			switch {
 			case errors.Is(err, domain.ErrUntrustedIssuer):
-				WriteError(w, http.StatusForbidden, "untrusted_issuer", err.Error())
+				reason = "untrusted_issuer"
+				WriteError(w, http.StatusForbidden, reason, err.Error())
 			case errors.Is(err, domain.ErrExpiredCredential), errors.Is(err, domain.ErrInvalidSignature), errors.Is(err, domain.ErrUnexpectedAudience), errors.Is(err, domain.ErrIssuedInFuture):
-				WriteError(w, http.StatusUnauthorized, "invalid_credential", err.Error())
+				reason = "invalid_credential"
+				WriteError(w, http.StatusUnauthorized, reason, err.Error())
 			default:
-				WriteError(w, http.StatusBadRequest, "verification_failed", err.Error())
+				WriteError(w, http.StatusBadRequest, reason, err.Error())
 			}
+			metrics.DefaultVerifierMetrics.IncVerificationFailure(reason)
 			return
 		}
 
@@ -85,6 +96,7 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			actingOnBehalfOf = chainResult.RootDelegator
 		}
 
+		metrics.DefaultVerifierMetrics.IncVerificationSuccess("ok")
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(VerifyResponse{
 			Valid:            true,

--- a/internal/httpx/verifier_handlers_test.go
+++ b/internal/httpx/verifier_handlers_test.go
@@ -1,26 +1,27 @@
 package httpx
 
 import (
-	"bytes"
-	"crypto"
-	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
+"bytes"
+"context"
+"crypto"
+"crypto/ed25519"
+"encoding/base64"
+"encoding/json"
+"net/http"
+"net/http/httptest"
+"strings"
+"testing"
+"time"
 
-	"github.com/bradtumy/credential-service/internal/domain"
+"github.com/bradtumy/credential-service/internal/domain"
 )
 
 func TestVerifierHandlerSuccess(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
-	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer("tenant", issuerDID)
+registry := domain.NewMemoryTrustRegistry()
+registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
 
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		if issuer != issuerDID {
@@ -67,8 +68,8 @@ func TestVerifierHandlerDelegatedCredential(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
-	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer("tenant", issuerDID)
+registry := domain.NewMemoryTrustRegistry()
+registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
 
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		if issuer != issuerDID {
@@ -116,8 +117,8 @@ func TestVerifierHandlerExpiredCredential(t *testing.T) {
 	_, priv, _ := ed25519.GenerateKey(nil)
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
-	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer("tenant", issuerDID)
+registry := domain.NewMemoryTrustRegistry()
+registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
 
 	resolver := func(string) (crypto.PublicKey, error) {
 		return priv.Public(), nil

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Logger is the global structured logger used across services.
+var Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+// Init configures the global logger with the provided level.
+func Init(level string) {
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: parseLevel(level)})
+	Logger = slog.New(handler)
+}
+
+func parseLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,25 @@
+package logging
+
+import "testing"
+
+func TestInitSetsLogger(t *testing.T) {
+	Init("debug")
+	if Logger == nil {
+		t.Fatalf("expected logger to be initialized")
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	if lvl := parseLevel("debug"); lvl != -4 {
+		t.Fatalf("expected debug level, got %v", lvl)
+	}
+	if lvl := parseLevel("warn"); lvl != 4 {
+		t.Fatalf("expected warn level, got %v", lvl)
+	}
+	if lvl := parseLevel("error"); lvl != 8 {
+		t.Fatalf("expected error level, got %v", lvl)
+	}
+	if lvl := parseLevel("unknown"); lvl != 0 {
+		t.Fatalf("expected info level fallback, got %v", lvl)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,19 @@
+package metrics
+
+// VerifierMetrics describes counters for verification outcomes.
+type VerifierMetrics interface {
+	IncVerificationSuccess(reason string)
+	IncVerificationFailure(reason string)
+}
+
+// NoopVerifierMetrics is a placeholder implementation used by default.
+type NoopVerifierMetrics struct{}
+
+// IncVerificationSuccess satisfies VerifierMetrics without recording metrics.
+func (NoopVerifierMetrics) IncVerificationSuccess(reason string) {}
+
+// IncVerificationFailure satisfies VerifierMetrics without recording metrics.
+func (NoopVerifierMetrics) IncVerificationFailure(reason string) {}
+
+// DefaultVerifierMetrics is the global metrics collector for the verifier.
+var DefaultVerifierMetrics VerifierMetrics = NoopVerifierMetrics{}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,30 @@
+package metrics
+
+import "testing"
+
+type counterMetrics struct {
+	success map[string]int
+	failure map[string]int
+}
+
+func (c *counterMetrics) IncVerificationSuccess(reason string) { c.success[reason]++ }
+func (c *counterMetrics) IncVerificationFailure(reason string) { c.failure[reason]++ }
+
+func TestNoopMetricsDoesNotPanic(t *testing.T) {
+	var m VerifierMetrics = NoopVerifierMetrics{}
+	m.IncVerificationSuccess("ok")
+	m.IncVerificationFailure("bad")
+}
+
+func TestCounterMetricsIncrements(t *testing.T) {
+	m := &counterMetrics{success: make(map[string]int), failure: make(map[string]int)}
+	m.IncVerificationSuccess("ok")
+	m.IncVerificationFailure("expired")
+
+	if m.success["ok"] != 1 {
+		t.Fatalf("expected success count to be 1, got %d", m.success["ok"])
+	}
+	if m.failure["expired"] != 1 {
+		t.Fatalf("expected failure count to be 1, got %d", m.failure["expired"])
+	}
+}

--- a/internal/storage/trust_registry_pg.go
+++ b/internal/storage/trust_registry_pg.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+)
+
+// PGTrustRegistry persists trusted issuers in Postgres.
+type PGTrustRegistry struct {
+	db *sql.DB
+}
+
+// NewPGTrustRegistry constructs a Postgres-backed trust registry.
+func NewPGTrustRegistry(db *sql.DB) *PGTrustRegistry {
+	return &PGTrustRegistry{db: db}
+}
+
+// IsTrustedIssuer returns whether the issuer is trusted for the given tenant.
+func (r *PGTrustRegistry) IsTrustedIssuer(ctx context.Context, tenantID, issuerDID string) (bool, error) {
+	const query = `SELECT 1 FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
+	var exists int
+	if err := r.db.QueryRowContext(ctx, query, tenantID, issuerDID).Scan(&exists); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// AddTrustedIssuer inserts a trusted issuer row. Duplicate inserts are ignored.
+func (r *PGTrustRegistry) AddTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error {
+	const stmt = `INSERT INTO trusted_issuers (tenant_id, issuer_did) VALUES ($1, $2) ON CONFLICT (tenant_id, issuer_did) DO NOTHING`
+	_, err := r.db.ExecContext(ctx, stmt, tenantID, issuerDID)
+	return err
+}
+
+// RemoveTrustedIssuer deletes a trusted issuer entry.
+func (r *PGTrustRegistry) RemoveTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error {
+	const stmt = `DELETE FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
+	_, err := r.db.ExecContext(ctx, stmt, tenantID, issuerDID)
+	return err
+}

--- a/internal/storage/trust_registry_pg_test.go
+++ b/internal/storage/trust_registry_pg_test.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPGTrustRegistry_AddTrustedIssuerIdempotent(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+
+	registry := NewPGTrustRegistry(mockDB)
+
+	insertRegex := regexp.QuoteMeta("INSERT INTO trusted_issuers (tenant_id, issuer_did) VALUES ($1, $2) ON CONFLICT (tenant_id, issuer_did) DO NOTHING")
+	mock.ExpectExec(insertRegex).
+		WithArgs("tenant-1", "did:example:issuer").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(insertRegex).
+		WithArgs("tenant-1", "did:example:issuer").
+		WillReturnResult(sqlmock.NewResult(1, 0))
+
+	if err := registry.AddTrustedIssuer(context.Background(), "tenant-1", "did:example:issuer"); err != nil {
+		t.Fatalf("unexpected error on insert: %v", err)
+	}
+	if err := registry.AddTrustedIssuer(context.Background(), "tenant-1", "did:example:issuer"); err != nil {
+		t.Fatalf("unexpected error on duplicate insert: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPGTrustRegistry_IsTrustedIssuer(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+
+	registry := NewPGTrustRegistry(mockDB)
+
+	selectRegex := regexp.QuoteMeta("SELECT 1 FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2")
+
+	mock.ExpectQuery(selectRegex).
+		WithArgs("tenant-1", "did:example:issuer").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+
+	mock.ExpectQuery(selectRegex).
+		WithArgs("tenant-1", "did:example:unknown").
+		WillReturnError(sql.ErrNoRows)
+
+	trusted, err := registry.IsTrustedIssuer(context.Background(), "tenant-1", "did:example:issuer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !trusted {
+		t.Fatalf("expected issuer to be trusted")
+	}
+
+	trusted, err = registry.IsTrustedIssuer(context.Background(), "tenant-1", "did:example:unknown")
+	if err != nil {
+		t.Fatalf("unexpected error on missing: %v", err)
+	}
+	if trusted {
+		t.Fatalf("expected unknown issuer to be untrusted")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/migrations/0001_create_trusted_issuers.sql
+++ b/migrations/0001_create_trusted_issuers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS trusted_issuers (
+    id SERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    issuer_did TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, issuer_did)
+);

--- a/test/integration/delegation_integration_test.go
+++ b/test/integration/delegation_integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"encoding/json"
 	"net/http"
@@ -37,7 +38,7 @@ func TestDelegationIntegration(t *testing.T) {
 
 	// Verifier server
 	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer(verifierCfg.DefaultTenantID, issuerDID)
+	registry.AddTrustedIssuer(context.Background(), verifierCfg.DefaultTenantID, issuerDID)
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		if issuer != issuerDID {
 			return nil, domain.ErrUntrustedIssuer

--- a/test/integration/verifier_integration_test.go
+++ b/test/integration/verifier_integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ed25519"
 	"encoding/base64"
@@ -32,7 +33,7 @@ func TestVerifierIntegration(t *testing.T) {
 	}
 
 	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer(cfg.DefaultTenantID, issuerDID)
+	registry.AddTrustedIssuer(context.Background(), cfg.DefaultTenantID, issuerDID)
 
 	keyMap := map[string]crypto.PublicKey{issuerDID: signer.Public()}
 	resolver := func(issuer string) (crypto.PublicKey, error) {
@@ -84,7 +85,7 @@ func TestVerifierIntegrationRejectsTamperedToken(t *testing.T) {
 	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
 
 	registry := domain.NewMemoryTrustRegistry()
-	registry.AddTrustedIssuer(cfg.DefaultTenantID, issuerDID)
+	registry.AddTrustedIssuer(context.Background(), cfg.DefaultTenantID, issuerDID)
 
 	keyMap := map[string]crypto.PublicKey{issuerDID: priv.Public()}
 	resolver := func(issuer string) (crypto.PublicKey, error) {


### PR DESCRIPTION
## Summary
- add a Postgres-backed trust registry implementation with SQL migration and tests
- extend verifier configuration, wire DB registry option, and introduce structured logging plus metrics hooks
- document security posture with a threat model and updated SECURITY guidelines

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b06b705f0832c93c5311dcc9eec9f)