### PR TITLE
Add Go and Node SDKs with quickstart and developer guide

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,66 @@
+# Credential Service Developer Guide
+
+Welcome! This guide introduces the key concepts, flows, and SDK options for building on the Credential Service. Use it alongside the 5-minute quickstart and the examples in the repo.
+
+## Core Concepts
+
+### Decentralized Identifiers (DIDs)
+- A DID is a cryptographically verifiable identifier (for example, `did:example:alice`).
+- Each DID has associated public/private keys that allow holders to sign and prove control of the identifier.
+- The service derives DIDs from signing keys so issuers and subjects can be uniquely addressed.
+
+### Verifiable Credentials (VCs)
+- A VC is a tamper-evident statement (JWT/JWS) that binds claims to a subject DID and is signed by an issuer DID.
+- Claims can include roles, scopes, audiences, or any JSON payload your application needs.
+- The verifier checks signatures, expiration, issuer trust, and audience before accepting a VC.
+
+### Delegation
+- A holder with a valid VC can delegate a subset of their permissions by requesting a delegated credential.
+- Delegation is constrained by scope and time-to-live and is always tied back to the original delegator.
+- The service enforces delegation depth limits to prevent unbounded chains.
+
+### Gateway Authorization
+- GatewayAuthorize verifies a credential chain and returns an allow/deny decision plus key identity fields:
+  - `subject`: the DID tied to the leaf credential.
+  - `acting_on_behalf_of`: the original delegator when delegation is used.
+  - `delegation_depth`: how deep the chain is.
+  - `claims`: merged claims from the chain.
+- Use this at your API gateway or middleware to keep authorization logic simple.
+
+### Synthetic JWTs
+- Optionally, GatewayAuthorize can mint a short-lived synthetic JWT signed by the service.
+- This token packages the decision (subject, claims, delegation info) so downstream services can verify quickly without re-running full VC verification.
+- The token is EdDSA-signed; verify it with the published public key in your gateway or services.
+
+## SDK Guidance
+
+- **Go SDK (`sdk/go`)**: Best for backends and gateways written in Go. Exposes typed helpers for issuing, delegating, verifying, and authorizing credentials.
+- **Node SDK (`sdk/node`)**: Ideal for JavaScript/TypeScript services or edge runtimes. Ships with TypeScript definitions for a smooth DX.
+
+## Typical Flow
+
+1. Issue a base credential for a subject DID.
+2. (Optional) Delegate a subset of permissions to another DID.
+3. Present the credential chain to GatewayAuthorize to receive an authorization decision and, if desired, a synthetic JWT.
+4. Call downstream APIs with the synthetic JWT in the `Authorization: Bearer` header.
+
+## Text Diagrams
+
+Credential issuance:
+```
+[Issuer DID] --signs--> [Credential JWT] --bound to--> [Subject DID]
+```
+
+Delegation chain:
+```
+Issuer --issue--> Parent VC --delegate--> Child VC --delegate--> Grandchild VC
+   |                                                   |
+acting_on_behalf_of = Issuer DID             delegation_depth = 2
+```
+
+Gateway decision with synthetic JWT:
+```
+[Client] --VC--> [GatewayAuthorize] --allow + synthetic_jwt--> [API / Service]
+```
+
+Happy shipping!

--- a/README.md
+++ b/README.md
@@ -2,6 +2,56 @@
 
 A robust microservice designed for creating, managing, and verifying **W3C-compliant Verifiable Credentials (VCs)**. This service allows organizations to issue credentials, link them to **Decentralized Identifiers (DIDs)**, and enable secure, privacy-preserving verification across multiple platforms.
 
+## 🚀 5-Minute Quickstart
+
+1. **Start the stack**
+
+   ```bash
+   docker compose up --build
+   ```
+
+2. **Install an SDK**
+
+   Go:
+
+   ```bash
+   go get github.com/bradtumy/credential-service/sdk/go
+   ```
+
+   Node:
+
+   ```bash
+   npm install @credential-service/sdk
+   ```
+
+3. **Create a client and issue a credential**
+
+   ```go
+   client := &sdk.Client{BaseURL: "http://localhost:8080"}
+   issued, _ := client.IssueCredential(context.Background(), sdk.IssueRequest{
+       SubjectDID: "did:example:alice",
+       TTLSeconds: 600,
+       Claims: map[string]interface{}{"aud": "example-api"},
+   })
+   ```
+
+4. **Authorize with the gateway and get a synthetic JWT**
+
+   ```go
+   decision, _ := client.GatewayAuthorize(context.Background(), sdk.GatewayAuthorizeRequest{
+       Credential:       issued.Credential,
+       ExpectedAudience: "example-api",
+       WantSyntheticJWT: true,
+   })
+   token := decision.SyntheticJWT
+   ```
+
+5. **Call your protected API with the synthetic JWT**
+
+   ```bash
+   curl -H "Authorization: Bearer $token" http://localhost:8081/hello
+   ```
+
 ## What Are DIDs and VCs?
 
 Decentralized Identifiers (DIDs) are unique digital identifiers backed by cryptographic keys. They are not anchored to any single company or database, giving people, services, and AI agents a portable way to prove who they are without relying on a central authority.

--- a/examples/go-basic/main.go
+++ b/examples/go-basic/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	sdk "github.com/bradtumy/credential-service/sdk/go"
+)
+
+func main() {
+	client := &sdk.Client{BaseURL: "http://localhost:8080"}
+	ctx := context.Background()
+
+	issued, err := client.IssueCredential(ctx, sdk.IssueRequest{
+		SubjectDID: "did:example:alice",
+		TTLSeconds: int64((10 * time.Minute).Seconds()),
+		Claims:     map[string]interface{}{"aud": "example-api", "role": "admin"},
+	})
+	if err != nil {
+		log.Fatalf("issue credential: %v", err)
+	}
+
+	decision, err := client.GatewayAuthorize(ctx, sdk.GatewayAuthorizeRequest{
+		Credential:       issued.Credential,
+		ExpectedAudience: "example-api",
+		WantSyntheticJWT: true,
+	})
+	if err != nil {
+		log.Fatalf("gateway authorize: %v", err)
+	}
+
+	fmt.Printf("Subject: %s\n", decision.Subject)
+	fmt.Printf("Acting on behalf of: %s\n", decision.ActingOnBehalfOf)
+	fmt.Printf("Claims: %#v\n", decision.Claims)
+	if decision.SyntheticJWT != "" {
+		fmt.Printf("Synthetic JWT: %s\n", decision.SyntheticJWT)
+	}
+}

--- a/examples/node-basic/index.js
+++ b/examples/node-basic/index.js
@@ -1,0 +1,29 @@
+import { Client } from '../../sdk/node/index.js';
+
+async function main() {
+  const client = new Client({ baseUrl: 'http://localhost:8080' });
+
+  const issued = await client.issueCredential({
+    subject_did: 'did:example:alice',
+    ttl_seconds: 600,
+    claims: { aud: 'example-api', role: 'admin' }
+  });
+
+  const decision = await client.gatewayAuthorize({
+    credential: issued.credential,
+    expected_audience: 'example-api',
+    want_synthetic_jwt: true
+  });
+
+  console.log('Subject:', decision.subject);
+  console.log('Acting on behalf of:', decision.acting_on_behalf_of || decision.subject);
+  console.log('Claims:', decision.claims);
+  if (decision.synthetic_jwt) {
+    console.log('Synthetic JWT:', decision.synthetic_jwt);
+  }
+}
+
+main().catch((err) => {
+  console.error('example error', err);
+  process.exit(1);
+});

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/bradtumy/credential-service
 go 1.22
 
 require (
-	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.1
-	github.com/hashicorp/vault/api v1.15.0
-	github.com/jackc/pgx/v4 v4.18.3
-	github.com/streadway/amqp v1.1.0
+        github.com/bradtumy/credential-service/sdk/go v0.0.0
+        github.com/google/uuid v1.6.0
+        github.com/gorilla/mux v1.8.1
+        github.com/hashicorp/vault/api v1.15.0
+        github.com/jackc/pgx/v4 v4.18.3
+        github.com/streadway/amqp v1.1.0
 )
 
 require (
@@ -40,3 +41,5 @@ require (
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 )
+
+replace github.com/bradtumy/credential-service/sdk/go => ./sdk/go

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,47 @@
+# Credential Service Go SDK
+
+A lightweight Go client for issuing, delegating, verifying, and authorizing Verifiable Credentials with the Credential Service.
+
+## Installation
+
+```bash
+go get github.com/bradtumy/credential-service/sdk/go
+```
+
+## Usage
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    sdk "github.com/bradtumy/credential-service/sdk/go"
+)
+
+func main() {
+    client := &sdk.Client{BaseURL: "http://localhost:8080"}
+    issued, err := client.IssueCredential(context.Background(), sdk.IssueRequest{
+        SubjectDID: "did:example:alice",
+        TTLSeconds: 600,
+        Claims: map[string]interface{}{"aud": "example-api"},
+    })
+    if err != nil {
+        log.Fatalf("issue failed: %v", err)
+    }
+
+    decision, err := client.GatewayAuthorize(context.Background(), sdk.GatewayAuthorizeRequest{
+        Credential:       issued.Credential,
+        ExpectedAudience: "example-api",
+        WantSyntheticJWT: true,
+    })
+    if err != nil {
+        log.Fatalf("authorize failed: %v", err)
+    }
+
+    log.Printf("allowed=%v subject=%s acting_for=%s synthetic_jwt=%s", decision.Allowed, decision.Subject, decision.ActingOnBehalfOf, decision.SyntheticJWT)
+}
+```
+
+See the repository root `README.md` for the 5-minute quickstart and more examples.

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,0 +1,68 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a lightweight HTTP client for the credential services.
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: 15 * time.Second}
+}
+
+func (c *Client) buildURL(path string) string {
+	base := strings.TrimSuffix(c.BaseURL, "/")
+	if strings.HasPrefix(path, "/") {
+		return base + path
+	}
+	return base + "/" + path
+}
+
+func (c *Client) post(ctx context.Context, path string, payload interface{}, out interface{}) error {
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL(path), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrNetwork, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return mapStatusToError(resp.StatusCode)
+	}
+
+	if out == nil {
+		io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,0 +1,143 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestIssueCredential(t *testing.T) {
+	var captured IssueRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/issue" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(IssueResponse{
+			Credential:       "token123",
+			Subject:          captured.SubjectDID,
+			ActingOnBehalfOf: captured.SubjectDID,
+			DelegationDepth:  0,
+			Claims:           captured.Claims,
+		})
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL}
+	req := IssueRequest{SubjectDID: "did:example:alice", TTLSeconds: 600, Claims: map[string]interface{}{"aud": "example"}}
+	resp, err := client.IssueCredential(context.Background(), req)
+	if err != nil {
+		t.Fatalf("IssueCredential returned error: %v", err)
+	}
+
+	if resp.Credential != "token123" || resp.Subject != "did:example:alice" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if !reflect.DeepEqual(resp.Claims, req.Claims) {
+		t.Fatalf("claims mismatch: %+v", resp.Claims)
+	}
+	if captured.TTLSeconds != req.TTLSeconds {
+		t.Fatalf("ttl mismatch: %d", captured.TTLSeconds)
+	}
+}
+
+func TestDelegateCredential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/delegate" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DelegateResponse{Credential: "delegated", DelegationDepth: 1, ActingOnBehalfOf: "did:parent"})
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL}
+	resp, err := client.DelegateCredential(context.Background(), DelegateRequest{ParentCredential: "parent", DelegateDID: "did:child", Scope: []string{"read"}, TTLSeconds: 300})
+	if err != nil {
+		t.Fatalf("DelegateCredential returned error: %v", err)
+	}
+	if resp.Credential != "delegated" || resp.DelegationDepth != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestVerify(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(VerifyResponse{Valid: true, Subject: "did:subject", DelegationDepth: 0, Claims: map[string]interface{}{"role": "admin"}})
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL}
+	resp, err := client.Verify(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !resp.Valid || resp.Subject != "did:subject" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.Claims["role"] != "admin" {
+		t.Fatalf("missing claim role")
+	}
+}
+
+func TestGatewayAuthorize(t *testing.T) {
+	var captured GatewayAuthorizeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(GatewayAuthorizeResponse{Allowed: true, Subject: "did:subject", ActingOnBehalfOf: "did:parent", DelegationDepth: 1, Claims: map[string]interface{}{"scope": []string{"read"}}, SyntheticJWT: "jwt"})
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL}
+	req := GatewayAuthorizeRequest{Credential: "token", ExpectedAudience: "api", WantSyntheticJWT: true}
+	resp, err := client.GatewayAuthorize(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GatewayAuthorize returned error: %v", err)
+	}
+	if !resp.Allowed || resp.SyntheticJWT != "jwt" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if !captured.WantSyntheticJWT || captured.ExpectedAudience != "api" {
+		t.Fatalf("unexpected request captured: %+v", captured)
+	}
+}
+
+func TestErrorMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		want   error
+	}{
+		{400, ErrInvalidCredential},
+		{401, ErrUnauthorized},
+		{403, ErrUnauthorized},
+		{500, ErrServerError},
+	}
+
+	for _, tc := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+		client := &Client{BaseURL: srv.URL}
+		_, err := client.IssueCredential(context.Background(), IssueRequest{SubjectDID: "did:ex", TTLSeconds: 1})
+		srv.Close()
+
+		if !errors.Is(err, tc.want) {
+			t.Fatalf("status %d: expected %v got %v", tc.status, tc.want, err)
+		}
+	}
+}

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -1,0 +1,27 @@
+package sdk
+
+import "errors"
+
+var (
+	// ErrUnauthorized indicates the credential or request was not authorized.
+	ErrUnauthorized = errors.New("unauthorized")
+	// ErrInvalidCredential indicates the provided credential was invalid or malformed.
+	ErrInvalidCredential = errors.New("invalid_credential")
+	// ErrServerError represents a server-side failure.
+	ErrServerError = errors.New("server_error")
+	// ErrNetwork represents network or transport failures.
+	ErrNetwork = errors.New("network_error")
+)
+
+func mapStatusToError(status int) error {
+	switch {
+	case status == 400:
+		return ErrInvalidCredential
+	case status == 401 || status == 403:
+		return ErrUnauthorized
+	case status >= 500:
+		return ErrServerError
+	default:
+		return ErrNetwork
+	}
+}

--- a/sdk/go/gateway.go
+++ b/sdk/go/gateway.go
@@ -1,0 +1,12 @@
+package sdk
+
+import "context"
+
+// GatewayAuthorize validates credentials and returns an authorization decision.
+func (c *Client) GatewayAuthorize(ctx context.Context, req GatewayAuthorizeRequest) (*GatewayAuthorizeResponse, error) {
+	var resp GatewayAuthorizeResponse
+	if err := c.post(ctx, "/v1/gateway/authorize", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,6 @@
+module github.com/bradtumy/credential-service/sdk/go
+
+go 1.22
+
+require (
+)

--- a/sdk/go/issuer.go
+++ b/sdk/go/issuer.go
@@ -1,0 +1,21 @@
+package sdk
+
+import "context"
+
+// IssueCredential calls the issuer endpoint to mint a new credential.
+func (c *Client) IssueCredential(ctx context.Context, req IssueRequest) (*IssueResponse, error) {
+	var resp IssueResponse
+	if err := c.post(ctx, "/v1/credentials/issue", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DelegateCredential calls the delegation endpoint to mint a delegated credential.
+func (c *Client) DelegateCredential(ctx context.Context, req DelegateRequest) (*DelegateResponse, error) {
+	var resp DelegateResponse
+	if err := c.post(ctx, "/v1/credentials/delegate", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -1,0 +1,68 @@
+package sdk
+
+// IssueRequest represents a request to issue a verifiable credential.
+type IssueRequest struct {
+	SubjectDID string                 `json:"subject_did"`
+	TTLSeconds int64                  `json:"ttl_seconds"`
+	Claims     map[string]interface{} `json:"claims,omitempty"`
+}
+
+// IssueResponse contains the issued credential token and associated metadata.
+type IssueResponse struct {
+	Credential       string                 `json:"credential"`
+	Subject          string                 `json:"subject,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+}
+
+// DelegateRequest represents a delegation issuance request.
+type DelegateRequest struct {
+	ParentCredential string                 `json:"parent_credential"`
+	DelegateDID      string                 `json:"delegate_did"`
+	Scope            []string               `json:"scope"`
+	TTLSeconds       int64                  `json:"ttl_seconds"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+}
+
+// DelegateResponse contains the delegated credential token and metadata.
+type DelegateResponse struct {
+	Credential       string                 `json:"credential"`
+	Subject          string                 `json:"subject,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+}
+
+// VerifyResponse represents verification details for a credential chain.
+type VerifyResponse struct {
+	Valid            bool                   `json:"valid"`
+	Subject          string                 `json:"subject"`
+	Issuer           string                 `json:"issuer,omitempty"`
+	ExpiresAt        string                 `json:"expires_at,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+}
+
+// GatewayAuthorizeRequest is the payload expected by the gateway authorize endpoint.
+type GatewayAuthorizeRequest struct {
+	Credential       string   `json:"credential"`
+	Credentials      []string `json:"credentials"`
+	ExpectedAudience string   `json:"expected_audience"`
+	WantSyntheticJWT bool     `json:"want_synthetic_jwt"`
+}
+
+// GatewayAuthorizeResponse is returned when authorizing a request at the gateway.
+type GatewayAuthorizeResponse struct {
+	Allowed          bool                   `json:"allowed"`
+	Subject          string                 `json:"subject,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	Reason           string                 `json:"reason,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+}

--- a/sdk/go/verifier.go
+++ b/sdk/go/verifier.go
@@ -1,0 +1,15 @@
+package sdk
+
+import "context"
+
+// Verify submits a credential token or chain for verification.
+func (c *Client) Verify(ctx context.Context, token string) (*VerifyResponse, error) {
+	req := map[string]interface{}{
+		"credential": token,
+	}
+	var resp VerifyResponse
+	if err := c.post(ctx, "/v1/credentials/verify", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -1,0 +1,33 @@
+# Credential Service Node SDK
+
+Minimal Node.js client for issuing, delegating, verifying, and authorizing Verifiable Credentials against the Credential Service APIs.
+
+## Installation
+
+```bash
+npm install @credential-service/sdk
+```
+
+## Usage
+
+```js
+import { Client } from '@credential-service/sdk';
+
+const client = new Client({ baseUrl: 'http://localhost:8080' });
+
+const issued = await client.issueCredential({
+  subject_did: 'did:example:alice',
+  ttl_seconds: 600,
+  claims: { aud: 'example-api' }
+});
+
+const decision = await client.gatewayAuthorize({
+  credential: issued.credential,
+  expected_audience: 'example-api',
+  want_synthetic_jwt: true
+});
+
+console.log('allowed', decision.allowed, 'subject', decision.subject);
+```
+
+See the repository root quickstart for a full walk-through.

--- a/sdk/node/client.js
+++ b/sdk/node/client.js
@@ -1,0 +1,66 @@
+class BaseError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export class InvalidRequestError extends BaseError {}
+export class UnauthorizedError extends BaseError {}
+export class ServerError extends BaseError {}
+export class NetworkError extends BaseError {}
+
+export class Client {
+  constructor({ baseUrl, fetchImpl } = {}) {
+    this.baseUrl = baseUrl?.replace(/\/$/, '') || '';
+    this.fetchImpl = fetchImpl || globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error('fetch implementation required');
+    }
+  }
+
+  async issueCredential(request) {
+    return this.#post('/v1/credentials/issue', request);
+  }
+
+  async delegateCredential(request) {
+    return this.#post('/v1/credentials/delegate', request);
+  }
+
+  async verify(token) {
+    return this.#post('/v1/credentials/verify', { credential: token });
+  }
+
+  async gatewayAuthorize(request) {
+    return this.#post('/v1/gateway/authorize', request);
+  }
+
+  async #post(path, payload) {
+    const url = `${this.baseUrl}${path}`;
+    let res;
+    try {
+      res = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(payload || {})
+      });
+    } catch (err) {
+      throw new NetworkError('network_error', err?.status);
+    }
+
+    if (!res.ok) {
+      throw this.#mapError(res.status);
+    }
+
+    const text = await res.text();
+    if (!text) return {};
+    return JSON.parse(text);
+  }
+
+  #mapError(status) {
+    if (status === 400) return new InvalidRequestError('invalid_request', status);
+    if (status === 401 || status === 403) return new UnauthorizedError('unauthorized', status);
+    if (status >= 500) return new ServerError('server_error', status);
+    return new NetworkError('network_error', status);
+  }
+}

--- a/sdk/node/index.js
+++ b/sdk/node/index.js
@@ -1,0 +1,1 @@
+export { Client, InvalidRequestError, UnauthorizedError, ServerError, NetworkError } from './client.js';

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@credential-service/sdk",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/sdk/node/test.js
+++ b/sdk/node/test.js
@@ -1,0 +1,16 @@
+import { Client } from './index.js';
+
+async function run() {
+  const client = new Client({
+    baseUrl: 'http://localhost:0',
+    fetchImpl: async () => ({ ok: true, status: 200, text: async () => '{}' })
+  });
+
+  await client.verify('dummy');
+  console.log('node sdk smoke test passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/sdk/node/types/index.d.ts
+++ b/sdk/node/types/index.d.ts
@@ -1,0 +1,47 @@
+export interface IssueRequest {
+  subject_did: string;
+  ttl_seconds: number;
+  claims?: Record<string, any>;
+}
+
+export interface DelegateRequest {
+  parent_credential: string;
+  delegate_did: string;
+  scope: string[];
+  ttl_seconds: number;
+  claims?: Record<string, any>;
+}
+
+export interface GatewayAuthorizeRequest {
+  credential?: string;
+  credentials?: string[];
+  expected_audience?: string;
+  want_synthetic_jwt?: boolean;
+}
+
+export interface IssueResponse {
+  credential: string;
+  subject?: string;
+  acting_on_behalf_of?: string;
+  delegation_depth?: number;
+  claims?: Record<string, any>;
+  synthetic_jwt?: string;
+}
+
+export interface GatewayAuthorizeResponse {
+  allowed: boolean;
+  subject?: string;
+  acting_on_behalf_of?: string;
+  delegation_depth?: number;
+  claims?: Record<string, any>;
+  reason?: string;
+  synthetic_jwt?: string;
+}
+
+export class Client {
+  constructor(config: { baseUrl: string; fetchImpl?: typeof fetch });
+  issueCredential(request: IssueRequest): Promise<IssueResponse>;
+  delegateCredential(request: DelegateRequest): Promise<IssueResponse>;
+  verify(token: string): Promise<any>;
+  gatewayAuthorize(request: GatewayAuthorizeRequest): Promise<GatewayAuthorizeResponse>;
+}


### PR DESCRIPTION
## Summary
- add standalone Go SDK with credential issuance, delegation, verification, gateway authorize helpers, and tests
- add minimal Node SDK with TypeScript types and smoke test
- document 5-minute quickstart, developer guide, and runnable Go/Node examples
- wire root module to new SDK for local examples

## Testing
- go test ./... -run TestNonexistent -count=1
- cd sdk/go && go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b0c702f44832cab39db70bf839c22)