### PR TITLE
Add multi-tenant support and policy skeleton

### DIFF
--- a/POLICY_ENGINE.md
+++ b/POLICY_ENGINE.md
@@ -1,0 +1,27 @@
+# Policy Engine Skeleton
+
+The policy engine evaluates authorization decisions after credentials are verified and the tenant is resolved. Day 12 ships a no-op engine to keep behavior backward compatible while establishing the contract for future ABAC/RBAC and delegation-aware policies.
+
+## Input Model
+- `TenantID`: Tenant derived from `X-Tenant-ID` or the default tenant in single-tenant mode
+- `Subject`: DID of the acting subject
+- `ActingOnBehalfOf`: Delegation chain root (if applicable)
+- `Scope`: Requested scopes derived from credential claims
+- `Claims`: Raw claims from the leaf credential
+- `Resource`: Target resource (e.g., expected audience)
+- `Action`: Operation being authorized (e.g., `gateway_authorize`)
+- `Context`: Additional request context (path, delegation depth, etc.)
+
+## Output Model
+- `Allow`: Boolean decision
+- `Reason`: Optional string describing the decision path
+
+## Why a No-Op Default?
+The default engine returns `Allow=true` with reason `allow_all` to avoid breaking existing integrations. It ensures a clean upgrade path while letting downstream deployments plug in richer engines later.
+
+## Roadmap
+- Attribute-based access control (ABAC)
+- Role-based access control (RBAC)
+- Permissioned delegation chains
+- Resource/action templates for gateways
+- Policy-as-code integration with versioned bundles

--- a/TENANCY.md
+++ b/TENANCY.md
@@ -1,0 +1,32 @@
+# Tenancy Fundamentals
+
+Multi-tenancy allows isolated credential issuance, verification, and policy evaluation for distinct customers or environments while sharing a common platform runtime. It keeps keys, trust anchors, and audit trails scoped to the tenant boundary and enables safer delegation and rotation workflows.
+
+## Modes
+- **Single-tenant (default):** Behaves like prior releases. The `DEFAULT_TENANT_ID` is injected automatically when the `X-Tenant-ID` header is absent.
+- **Multi-tenant:** Requires explicit tenant selection via `X-Tenant-ID`. Requests without a tenant fail fast to prevent cross-tenant leakage.
+
+## Request Flow
+```
+[Client] --X-Tenant-ID--> [Tenant Middleware] --validates--> [Handler]
+      |                                            |
+      |                         injects tenant into context
+      +--> Trust registry + policy engine consulted with tenant scope
+```
+
+## Trust Registry per Tenant
+Trusted issuers are stored per-tenant (database or in-memory). Lookups always include the resolved tenant ID, ensuring issuers trusted for one tenant are not implicitly trusted for another.
+
+## Tenant Discovery
+Tenants are resolved in this order:
+1. `X-Tenant-ID` header (required in multi-tenant mode)
+2. Default tenant when running in single-tenant mode
+3. Validation against the tenant store (Postgres or in-memory)
+
+Disabled or unknown tenants return a clear API error before any business logic executes.
+
+## Deployment Notes
+- Set `TENANCY_MODE=multi` to enforce explicit tenant selection.
+- Seed the `tenants` table (or in-memory store) with enabled tenants and default signing keys.
+- Database migrations add `tenants` and `tenant_trusted_issuers` tables; existing flows continue to work with the legacy single-tenant defaults.
+- Docker Compose continues to run in single-tenant mode unless overridden via environment variables.

--- a/cmd/issuer/main.go
+++ b/cmd/issuer/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 
 	"github.com/bradtumy/credential-service/internal/config"
+	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/tenant"
 )
 
 func main() {
@@ -15,11 +18,16 @@ func main() {
 	logging.Init(cfg.LogLevel)
 	store := keystore.NewMemoryKeyStore()
 
+	tenantStore := tenant.NewMemoryStore()
+	_ = tenantStore.UpsertTenant(context.Background(), domain.Tenant{ID: cfg.DefaultTenantID, Name: "default", Enabled: true})
+
+	resolver := tenant.Resolver{Mode: tenant.Mode(cfg.TenancyMode), DefaultTenantID: cfg.DefaultTenantID, Store: tenantStore}
+
 	mux := http.NewServeMux()
 	httpx.RegisterIssuerRoutes(mux, store, cfg)
 	httpx.RegisterHealthRoutes(mux, nil)
 
-	handler := httpx.RequestContext(httpx.LoggingMiddleware(mux))
+	handler := httpx.RequestContext(httpx.TenantMiddleware(resolver, httpx.LoggingMiddleware(mux)))
 
 	log.Printf("Issuer service running on port %s", cfg.HTTPPort)
 	if err := http.ListenAndServe(":"+cfg.HTTPPort, handler); err != nil {

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -16,7 +16,9 @@ import (
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/policy"
 	"github.com/bradtumy/credential-service/internal/storage"
+	"github.com/bradtumy/credential-service/internal/tenant"
 )
 
 func main() {
@@ -28,6 +30,9 @@ func main() {
 		db            *sql.DB
 	)
 
+	tenancyMode := tenant.Mode(cfg.TenancyMode)
+	var tenantStore tenant.Store = tenant.NewMemoryStore()
+
 	if cfg.UseDBTrustRegistry && cfg.DB_DSN != "" {
 		var err error
 		db, err = sql.Open("postgres", cfg.DB_DSN)
@@ -35,7 +40,14 @@ func main() {
 			log.Fatalf("connect to database: %v", err)
 		}
 		trustRegistry = storage.NewPGTrustRegistry(db)
+		tenantStore = tenant.NewPGTenantStore(db)
 	}
+
+	if err := tenantStore.UpsertTenant(context.Background(), domain.Tenant{ID: cfg.DefaultTenantID, Name: "default", Enabled: true}); err != nil {
+		log.Fatalf("seed default tenant: %v", err)
+	}
+
+	tenantResolver := tenant.Resolver{Mode: tenancyMode, DefaultTenantID: cfg.DefaultTenantID, Store: tenantStore}
 
 	issuerKeys := make(map[string]crypto.PublicKey)
 
@@ -72,10 +84,10 @@ func main() {
 
 	mux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
-	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, signer, issuerDID, time.Now)
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policy.NoOpEngine{}, cfg.DefaultTenantID, signer, issuerDID, time.Now)
 	httpx.RegisterHealthRoutes(mux, readiness)
 
-	handler := httpx.RequestContext(httpx.LoggingMiddleware(mux))
+	handler := httpx.RequestContext(httpx.TenantMiddleware(tenantResolver, httpx.LoggingMiddleware(mux)))
 
 	log.Printf("Verifier service running on port %s...", cfg.HTTPPort)
 	log.Fatal(http.ListenAndServe(":"+cfg.HTTPPort, handler))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,36 +39,40 @@ func getenv(key, fallback string) string {
 
 // IssuerConfig holds configuration for the issuer service.
 type IssuerConfig struct {
-	HTTPPort        string
-	DefaultTenantID string
-	LogLevel        string
+        HTTPPort        string
+        DefaultTenantID string
+        TenancyMode     string
+        LogLevel        string
 }
 
 // LoadIssuerConfigFromEnv loads issuer configuration from environment variables.
 func LoadIssuerConfigFromEnv() IssuerConfig {
-	return IssuerConfig{
-		HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
-		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
-		LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
-	}
+        return IssuerConfig{
+                HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
+                DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+                TenancyMode:     getenv("TENANCY_MODE", "single"),
+                LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
+        }
 }
 
 // VerifierConfig holds configuration for the verifier service.
 type VerifierConfig struct {
-	HTTPPort           string
-	DefaultTenantID    string
-	DB_DSN             string
-	UseDBTrustRegistry bool
-	LogLevel           string
+        HTTPPort           string
+        DefaultTenantID    string
+        DB_DSN             string
+        UseDBTrustRegistry bool
+        TenancyMode        string
+        LogLevel           string
 }
 
 // LoadVerifierConfigFromEnv loads verifier configuration from environment variables.
 func LoadVerifierConfigFromEnv() VerifierConfig {
-	return VerifierConfig{
-		HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
-		DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
-		DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
-		UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
-		LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
-	}
+        return VerifierConfig{
+                HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
+                DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
+                DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
+                UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
+                TenancyMode:        getenv("TENANCY_MODE", "single"),
+                LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
+        }
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,9 @@ func TestLoadIssuerConfigFromEnvDefaults(t *testing.T) {
 	if cfg.DefaultTenantID != "default-tenant" {
 		t.Fatalf("expected default tenant id, got %s", cfg.DefaultTenantID)
 	}
+	if cfg.TenancyMode != "single" {
+		t.Fatalf("expected default tenancy mode single, got %s", cfg.TenancyMode)
+	}
 	if cfg.LogLevel != "info" {
 		t.Fatalf("expected default log level info, got %s", cfg.LogLevel)
 	}
@@ -24,6 +27,7 @@ func TestLoadIssuerConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("ISSUER_HTTP_PORT", "9090")
 	t.Setenv("DEFAULT_TENANT_ID", "tenant-123")
 	t.Setenv("ISSUER_LOG_LEVEL", "debug")
+	t.Setenv("TENANCY_MODE", "multi")
 
 	cfg := LoadIssuerConfigFromEnv()
 
@@ -32,6 +36,9 @@ func TestLoadIssuerConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.DefaultTenantID != "tenant-123" {
 		t.Fatalf("expected tenant-123, got %s", cfg.DefaultTenantID)
+	}
+	if cfg.TenancyMode != "multi" {
+		t.Fatalf("expected tenancy mode override, got %s", cfg.TenancyMode)
 	}
 	if cfg.LogLevel != "debug" {
 		t.Fatalf("expected debug log level, got %s", cfg.LogLevel)
@@ -53,6 +60,9 @@ func TestLoadVerifierConfigFromEnvDefaults(t *testing.T) {
 	if cfg.DefaultTenantID != "default-tenant" {
 		t.Fatalf("expected default tenant id, got %s", cfg.DefaultTenantID)
 	}
+	if cfg.TenancyMode != "single" {
+		t.Fatalf("expected default tenancy mode single, got %s", cfg.TenancyMode)
+	}
 	if cfg.DB_DSN != "" {
 		t.Fatalf("expected empty DB DSN, got %s", cfg.DB_DSN)
 	}
@@ -70,6 +80,7 @@ func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("VERIFIER_DB_DSN", "postgres://example")
 	t.Setenv("VERIFIER_USE_DB_TRUST_REGISTRY", "true")
 	t.Setenv("VERIFIER_LOG_LEVEL", "warn")
+	t.Setenv("TENANCY_MODE", "multi")
 
 	cfg := LoadVerifierConfigFromEnv()
 
@@ -78,6 +89,9 @@ func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.DefaultTenantID != "tenant-verifier" {
 		t.Fatalf("expected tenant-verifier, got %s", cfg.DefaultTenantID)
+	}
+	if cfg.TenancyMode != "multi" {
+		t.Fatalf("expected multi tenancy mode, got %s", cfg.TenancyMode)
 	}
 	if cfg.DB_DSN != "postgres://example" {
 		t.Fatalf("expected DSN override, got %s", cfg.DB_DSN)

--- a/internal/domain/tenant.go
+++ b/internal/domain/tenant.go
@@ -1,6 +1,17 @@
 package domain
 
-// TenantContext captures multi-tenant request metadata.
+import "time"
+
+// Tenant represents a logical tenant within the platform.
+type Tenant struct {
+	ID        string
+	Name      string
+	Enabled   bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// TenantContext captures basic tenant-scoped request metadata.
 type TenantContext struct {
 	TenantID  string
 	RequestID string

--- a/internal/httpx/gateway_handlers.go
+++ b/internal/httpx/gateway_handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/metrics"
+	"github.com/bradtumy/credential-service/internal/policy"
 	"github.com/bradtumy/credential-service/internal/version"
 )
 
@@ -31,6 +32,7 @@ type GatewayAuthorizeResponse struct {
 	Reason           string                 `json:"reason,omitempty"`
 	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
 	Agent            *AgentContext          `json:"agent,omitempty"`
+	TenantID         string                 `json:"tenant_id,omitempty"`
 	APIVersion       string                 `json:"api_version"`
 }
 
@@ -42,9 +44,13 @@ type AgentContext struct {
 }
 
 // RegisterGatewayRoutes wires gateway-specific routes into the provided mux.
-func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, tenantID string, signingKey crypto.Signer, jwtIssuer string, now func() time.Time) {
+func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, policyEngine policy.Engine, defaultTenantID string, signingKey crypto.Signer, jwtIssuer string, now func() time.Time) {
 	if now == nil {
 		now = time.Now
+	}
+
+	if policyEngine == nil {
+		policyEngine = policy.NoOpEngine{}
 	}
 
 	mux.HandleFunc("/v1/gateway/authorize", func(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +73,11 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		if len(tokens) == 0 {
 			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "credential is required")
 			return
+		}
+
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = defaultTenantID
 		}
 
 		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
@@ -94,6 +105,29 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		}
 
 		decision := domain.BuildAuthzDecisionFromVerification(chainResult)
+		evalInput := policy.EvaluationInput{
+			TenantID:         tenantID,
+			Subject:          decision.SubjectDID,
+			ActingOnBehalfOf: decision.ActingOnBehalfOf,
+			Scope:            domain.ScopeFromClaims(decision.Claims),
+			Claims:           decision.Claims,
+			Resource:         req.ExpectedAudience,
+			Action:           "gateway_authorize",
+			Context: map[string]any{
+				"delegation_depth": chainResult.DelegationDepth,
+				"path":             r.URL.Path,
+			},
+		}
+
+		policyResult, err := policyEngine.Evaluate(evalInput)
+		if err != nil {
+			WriteAPIError(w, http.StatusInternalServerError, "policy_error", err.Error())
+			return
+		}
+		if !policyResult.Allow {
+			WriteAPIError(w, http.StatusForbidden, "policy_denied", policyResult.Reason)
+			return
+		}
 		var agentContext *AgentContext
 		if len(chainResult.Credentials) > 1 {
 			parent := chainResult.Credentials[len(chainResult.Credentials)-2]
@@ -114,6 +148,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			Claims:           decision.Claims,
 			Reason:           decision.Reason,
 			Agent:            agentContext,
+			TenantID:         tenantID,
 			APIVersion:       version.APIVersion,
 		}
 

--- a/internal/httpx/gateway_handlers_test.go
+++ b/internal/httpx/gateway_handlers_test.go
@@ -35,7 +35,7 @@ func TestGatewayAuthorizeAllow(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
 
 	payload := GatewayAuthorizeRequest{Credential: token, WantSyntheticJWT: true}
 	body, _ := json.Marshal(payload)
@@ -82,7 +82,7 @@ func TestGatewayAuthorizeAgentContext(t *testing.T) {
 	childToken, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 2*time.Minute, map[string]interface{}{"scope": []string{"read"}})
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
 
 	payload := GatewayAuthorizeRequest{Credentials: []string{parentToken, childToken}, WantSyntheticJWT: true}
 	body, _ := json.Marshal(payload)
@@ -129,7 +129,7 @@ func TestGatewayAuthorizeDenyExpired(t *testing.T) {
 	cred := decodeCredentialForHandlerTest(t, token)
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, func() time.Time {
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, func() time.Time {
 		return cred.ExpiresAt.Add(time.Second)
 	})
 
@@ -168,7 +168,7 @@ func TestGatewayAuthorizeUntrustedIssuer(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
 
 	payload := GatewayAuthorizeRequest{Credential: token}
 	body, _ := json.Marshal(payload)

--- a/internal/httpx/issuer_handlers.go
+++ b/internal/httpx/issuer_handlers.go
@@ -59,7 +59,12 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			return
 		}
 
-		signer, err := store.GetSigningKey(cfg.DefaultTenantID)
+                tenantID := TenantIDFromContext(r.Context())
+                if tenantID == "" {
+                        tenantID = cfg.DefaultTenantID
+                }
+
+                signer, err := store.GetSigningKey(tenantID)
 		if err != nil {
 			WriteAPIError(w, http.StatusInternalServerError, "keystore_error", err.Error())
 			return
@@ -108,7 +113,12 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			return
 		}
 
-		signer, err := store.GetSigningKey(cfg.DefaultTenantID)
+                tenantID := TenantIDFromContext(r.Context())
+                if tenantID == "" {
+                        tenantID = cfg.DefaultTenantID
+                }
+
+                signer, err := store.GetSigningKey(tenantID)
 		if err != nil {
 			WriteAPIError(w, http.StatusInternalServerError, "keystore_error", err.Error())
 			return

--- a/internal/httpx/middleware_tenant.go
+++ b/internal/httpx/middleware_tenant.go
@@ -1,0 +1,39 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bradtumy/credential-service/internal/tenant"
+)
+
+// TenantMiddleware enforces tenant resolution rules before reaching handlers.
+func TenantMiddleware(resolver tenant.Resolver, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tnt, err := resolver.Resolve(r)
+		if err != nil {
+			status := http.StatusForbidden
+			code := "tenant_error"
+			switch err {
+			case tenant.ErrTenantNotFound:
+				status = http.StatusNotFound
+				code = "tenant_not_found"
+			case tenant.ErrTenantDisabled:
+				code = "tenant_disabled"
+			default:
+				code = "tenant_required"
+				if resolver.Mode == tenant.ModeSingle {
+					status = http.StatusInternalServerError
+				} else {
+					status = http.StatusBadRequest
+				}
+			}
+			WriteAPIError(w, status, code, err.Error())
+			return
+		}
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, tenantIDKey, tnt.ID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/httpx/middleware_tenant_test.go
+++ b/internal/httpx/middleware_tenant_test.go
@@ -1,0 +1,75 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/tenant"
+)
+
+func TestTenantMiddlewareMissingHeaderMulti(t *testing.T) {
+	store := tenant.NewMemoryStore()
+	_ = store.UpsertTenant(context.Background(), domain.Tenant{ID: "tenant-a", Enabled: true})
+
+	resolver := tenant.Resolver{Mode: tenant.ModeMulti, DefaultTenantID: "tenant-a", Store: store}
+
+	handler := TenantMiddleware(resolver, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+}
+
+func TestTenantMiddlewareDisabledTenant(t *testing.T) {
+	store := tenant.NewMemoryStore()
+	_ = store.UpsertTenant(context.Background(), domain.Tenant{ID: "tenant-b", Enabled: false})
+
+	resolver := tenant.Resolver{Mode: tenant.ModeMulti, DefaultTenantID: "tenant-b", Store: store}
+
+	handler := TenantMiddleware(resolver, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Tenant-ID", "tenant-b")
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", rr.Code)
+	}
+}
+
+func TestTenantMiddlewareSingleModeDefault(t *testing.T) {
+	store := tenant.NewMemoryStore()
+	_ = store.UpsertTenant(context.Background(), domain.Tenant{ID: "default", Enabled: true})
+
+	resolver := tenant.Resolver{Mode: tenant.ModeSingle, DefaultTenantID: "default", Store: store}
+
+	handler := TenantMiddleware(resolver, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if TenantIDFromContext(r.Context()) != "default" {
+			t.Fatalf("expected tenant to be injected")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+}

--- a/internal/httpx/verifier_handlers.go
+++ b/internal/httpx/verifier_handlers.go
@@ -32,7 +32,7 @@ type VerifyResponse struct {
 }
 
 // RegisterVerifierRoutes wires verifier HTTP routes into the provided mux.
-func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, tenantID string, now func() time.Time) {
+func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, defaultTenantID string, now func() time.Time) {
 	if now == nil {
 		now = time.Now
 	}
@@ -57,6 +57,11 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 		if len(tokens) == 0 {
 			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "credential is required")
 			return
+		}
+
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = defaultTenantID
 		}
 
 		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1,0 +1,24 @@
+package policy
+
+// Engine evaluates authorization decisions.
+type Engine interface {
+	Evaluate(input EvaluationInput) (EvaluationResult, error)
+}
+
+// EvaluationInput captures the attributes sent to the policy engine.
+type EvaluationInput struct {
+	TenantID         string
+	Subject          string
+	ActingOnBehalfOf string
+	Scope            []string
+	Claims           map[string]any
+	Resource         string
+	Action           string
+	Context          map[string]any
+}
+
+// EvaluationResult is returned by the policy engine.
+type EvaluationResult struct {
+	Allow  bool
+	Reason string
+}

--- a/internal/policy/engine_noop.go
+++ b/internal/policy/engine_noop.go
@@ -1,0 +1,10 @@
+package policy
+
+// NoOpEngine permits every request while policy rules are being developed.
+type NoOpEngine struct{}
+
+// Evaluate always allows the request.
+func (NoOpEngine) Evaluate(input EvaluationInput) (EvaluationResult, error) {
+	_ = input
+	return EvaluationResult{Allow: true, Reason: "allow_all"}, nil
+}

--- a/internal/storage/trust_registry_pg.go
+++ b/internal/storage/trust_registry_pg.go
@@ -17,7 +17,7 @@ func NewPGTrustRegistry(db *sql.DB) *PGTrustRegistry {
 
 // IsTrustedIssuer returns whether the issuer is trusted for the given tenant.
 func (r *PGTrustRegistry) IsTrustedIssuer(ctx context.Context, tenantID, issuerDID string) (bool, error) {
-	const query = `SELECT 1 FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
+	const query = `SELECT 1 FROM tenant_trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
 	var exists int
 	if err := r.db.QueryRowContext(ctx, query, tenantID, issuerDID).Scan(&exists); err != nil {
 		if err == sql.ErrNoRows {
@@ -30,14 +30,14 @@ func (r *PGTrustRegistry) IsTrustedIssuer(ctx context.Context, tenantID, issuerD
 
 // AddTrustedIssuer inserts a trusted issuer row. Duplicate inserts are ignored.
 func (r *PGTrustRegistry) AddTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error {
-	const stmt = `INSERT INTO trusted_issuers (tenant_id, issuer_did) VALUES ($1, $2) ON CONFLICT (tenant_id, issuer_did) DO NOTHING`
+	const stmt = `INSERT INTO tenant_trusted_issuers (tenant_id, issuer_did, metadata) VALUES ($1, $2, '{}') ON CONFLICT (tenant_id, issuer_did) DO UPDATE SET metadata = EXCLUDED.metadata`
 	_, err := r.db.ExecContext(ctx, stmt, tenantID, issuerDID)
 	return err
 }
 
 // RemoveTrustedIssuer deletes a trusted issuer entry.
 func (r *PGTrustRegistry) RemoveTrustedIssuer(ctx context.Context, tenantID, issuerDID string) error {
-	const stmt = `DELETE FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
+	const stmt = `DELETE FROM tenant_trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
 	_, err := r.db.ExecContext(ctx, stmt, tenantID, issuerDID)
 	return err
 }

--- a/internal/storage/trust_registry_pg_test.go
+++ b/internal/storage/trust_registry_pg_test.go
@@ -18,7 +18,7 @@ func TestPGTrustRegistry_AddTrustedIssuerIdempotent(t *testing.T) {
 
 	registry := NewPGTrustRegistry(mockDB)
 
-	insertRegex := regexp.QuoteMeta("INSERT INTO trusted_issuers (tenant_id, issuer_did) VALUES ($1, $2) ON CONFLICT (tenant_id, issuer_did) DO NOTHING")
+        insertRegex := regexp.QuoteMeta("INSERT INTO tenant_trusted_issuers (tenant_id, issuer_did, metadata) VALUES ($1, $2, '{}') ON CONFLICT (tenant_id, issuer_did) DO UPDATE SET metadata = EXCLUDED.metadata")
 	mock.ExpectExec(insertRegex).
 		WithArgs("tenant-1", "did:example:issuer").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -47,7 +47,7 @@ func TestPGTrustRegistry_IsTrustedIssuer(t *testing.T) {
 
 	registry := NewPGTrustRegistry(mockDB)
 
-	selectRegex := regexp.QuoteMeta("SELECT 1 FROM trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2")
+        selectRegex := regexp.QuoteMeta("SELECT 1 FROM tenant_trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2")
 
 	mock.ExpectQuery(selectRegex).
 		WithArgs("tenant-1", "did:example:issuer").

--- a/internal/tenant/resolver.go
+++ b/internal/tenant/resolver.go
@@ -1,0 +1,44 @@
+package tenant
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+// ErrTenantDisabled indicates the tenant is present but disabled.
+var ErrTenantDisabled = fmt.Errorf("tenant disabled")
+
+// Resolver determines the tenant for an incoming HTTP request.
+type Resolver struct {
+	Mode            Mode
+	DefaultTenantID string
+	Store           Store
+}
+
+// Resolve extracts the tenant ID from request headers or falls back to defaults.
+func (r Resolver) Resolve(req *http.Request) (domain.Tenant, error) {
+	if r.Store == nil {
+		return domain.Tenant{}, fmt.Errorf("tenant store not configured")
+	}
+
+	tenantID := req.Header.Get("X-Tenant-ID")
+	if tenantID == "" {
+		if r.Mode == ModeSingle {
+			tenantID = r.DefaultTenantID
+		} else {
+			return domain.Tenant{}, fmt.Errorf("tenant header required")
+		}
+	}
+
+	tenant, err := r.Store.GetTenant(req.Context(), tenantID)
+	if err != nil {
+		return domain.Tenant{}, err
+	}
+	if !tenant.Enabled {
+		return domain.Tenant{}, ErrTenantDisabled
+	}
+
+	return tenant, nil
+}

--- a/internal/tenant/store.go
+++ b/internal/tenant/store.go
@@ -1,0 +1,128 @@
+package tenant
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+// Mode configures tenancy behavior.
+type Mode string
+
+const (
+	ModeSingle Mode = "single"
+	ModeMulti  Mode = "multi"
+)
+
+// ErrTenantNotFound indicates the tenant does not exist.
+var ErrTenantNotFound = errors.New("tenant not found")
+
+// Store persists or retrieves tenant metadata.
+type Store interface {
+	GetTenant(ctx context.Context, id string) (domain.Tenant, error)
+	UpsertTenant(ctx context.Context, tenant domain.Tenant) error
+	ListTenants(ctx context.Context) ([]domain.Tenant, error)
+}
+
+// MemoryStore is an in-memory implementation useful for tests and dev.
+type MemoryStore struct {
+	tenants map[string]domain.Tenant
+}
+
+// NewMemoryStore constructs an empty in-memory tenant store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{tenants: make(map[string]domain.Tenant)}
+}
+
+// GetTenant returns tenant metadata.
+func (m *MemoryStore) GetTenant(_ context.Context, id string) (domain.Tenant, error) {
+	tenant, ok := m.tenants[id]
+	if !ok {
+		return domain.Tenant{}, ErrTenantNotFound
+	}
+	return tenant, nil
+}
+
+// UpsertTenant creates or updates a tenant entry.
+func (m *MemoryStore) UpsertTenant(_ context.Context, t domain.Tenant) error {
+	if t.ID == "" {
+		return errors.New("tenant id is required")
+	}
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = time.Now().UTC()
+	}
+	t.UpdatedAt = time.Now().UTC()
+	m.tenants[t.ID] = t
+	return nil
+}
+
+// ListTenants returns all tenants in memory.
+func (m *MemoryStore) ListTenants(_ context.Context) ([]domain.Tenant, error) {
+	out := make([]domain.Tenant, 0, len(m.tenants))
+	for _, t := range m.tenants {
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+// PGTenantStore persists tenants in Postgres.
+type PGTenantStore struct {
+	db *sql.DB
+}
+
+// NewPGTenantStore builds a Postgres-backed tenant store.
+func NewPGTenantStore(db *sql.DB) *PGTenantStore {
+	return &PGTenantStore{db: db}
+}
+
+// GetTenant fetches a tenant row by ID.
+func (p *PGTenantStore) GetTenant(ctx context.Context, id string) (domain.Tenant, error) {
+	const query = `SELECT id, name, enabled, created_at, updated_at FROM tenants WHERE id = $1`
+	var t domain.Tenant
+	if err := p.db.QueryRowContext(ctx, query, id).Scan(&t.ID, &t.Name, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.Tenant{}, ErrTenantNotFound
+		}
+		return domain.Tenant{}, err
+	}
+	return t, nil
+}
+
+// UpsertTenant inserts or updates tenant metadata.
+func (p *PGTenantStore) UpsertTenant(ctx context.Context, t domain.Tenant) error {
+	if t.ID == "" {
+		return errors.New("tenant id is required")
+	}
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = time.Now().UTC()
+	}
+	t.UpdatedAt = time.Now().UTC()
+
+	const stmt = `INSERT INTO tenants (id, name, enabled, created_at, updated_at) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, enabled = EXCLUDED.enabled, updated_at = EXCLUDED.updated_at`
+	_, err := p.db.ExecContext(ctx, stmt, t.ID, t.Name, t.Enabled, t.CreatedAt, t.UpdatedAt)
+	return err
+}
+
+// ListTenants returns tenants persisted in the database.
+func (p *PGTenantStore) ListTenants(ctx context.Context) ([]domain.Tenant, error) {
+	const query = `SELECT id, name, enabled, created_at, updated_at FROM tenants`
+	rows, err := p.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tenants := []domain.Tenant{}
+	for rows.Next() {
+		var t domain.Tenant
+		if err := rows.Scan(&t.ID, &t.Name, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, err
+		}
+		tenants = append(tenants, t)
+	}
+	return tenants, rows.Err()
+}

--- a/internal/trust/tenant_registry.go
+++ b/internal/trust/tenant_registry.go
@@ -1,0 +1,120 @@
+package trust
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// TenantTrustRegistry defines tenant-scoped trust registry operations.
+type TenantTrustRegistry interface {
+	IsTrusted(ctx context.Context, tenantID string, issuerDID string) (bool, error)
+	AddTrustedIssuer(ctx context.Context, tenantID, issuerDID string, md map[string]any) error
+	ListTrustedIssuers(ctx context.Context, tenantID string) ([]string, error)
+}
+
+// InMemoryTenantRegistry implements tenant trust registry with in-memory storage.
+type InMemoryTenantRegistry struct {
+	mu      sync.RWMutex
+	trusted map[string]map[string]map[string]any
+}
+
+// NewInMemoryTenantRegistry constructs an empty registry.
+func NewInMemoryTenantRegistry() *InMemoryTenantRegistry {
+	return &InMemoryTenantRegistry{trusted: make(map[string]map[string]map[string]any)}
+}
+
+// IsTrusted returns whether issuer is trusted for tenant.
+func (m *InMemoryTenantRegistry) IsTrusted(_ context.Context, tenantID, issuerDID string) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	issuers := m.trusted[tenantID]
+	if issuers == nil {
+		return false, nil
+	}
+	_, ok := issuers[issuerDID]
+	return ok, nil
+}
+
+// AddTrustedIssuer records issuer trust for tenant.
+func (m *InMemoryTenantRegistry) AddTrustedIssuer(_ context.Context, tenantID, issuerDID string, md map[string]any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.trusted[tenantID] == nil {
+		m.trusted[tenantID] = make(map[string]map[string]any)
+	}
+	m.trusted[tenantID][issuerDID] = md
+	return nil
+}
+
+// ListTrustedIssuers enumerates trusted issuers for tenant.
+func (m *InMemoryTenantRegistry) ListTrustedIssuers(_ context.Context, tenantID string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	issuers := m.trusted[tenantID]
+	res := make([]string, 0, len(issuers))
+	for id := range issuers {
+		res = append(res, id)
+	}
+	return res, nil
+}
+
+// PGTenantTrustRegistry stores trusted issuers per tenant in Postgres.
+type PGTenantTrustRegistry struct {
+	db *sql.DB
+}
+
+// NewPGTenantTrustRegistry constructs a Postgres-backed tenant trust registry.
+func NewPGTenantTrustRegistry(db *sql.DB) *PGTenantTrustRegistry {
+	return &PGTenantTrustRegistry{db: db}
+}
+
+// IsTrusted checks trust membership.
+func (p *PGTenantTrustRegistry) IsTrusted(ctx context.Context, tenantID string, issuerDID string) (bool, error) {
+	const query = `SELECT 1 FROM tenant_trusted_issuers WHERE tenant_id = $1 AND issuer_did = $2`
+	var exists int
+	if err := p.db.QueryRowContext(ctx, query, tenantID, issuerDID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// AddTrustedIssuer inserts trust entry with optional metadata.
+func (p *PGTenantTrustRegistry) AddTrustedIssuer(ctx context.Context, tenantID, issuerDID string, md map[string]any) error {
+	const stmt = `INSERT INTO tenant_trusted_issuers (tenant_id, issuer_did, metadata) VALUES ($1, $2, $3)
+ON CONFLICT (tenant_id, issuer_did) DO UPDATE SET metadata = EXCLUDED.metadata`
+	metaBytes, err := json.Marshal(md)
+	if err != nil {
+		return err
+	}
+	_, err = p.db.ExecContext(ctx, stmt, tenantID, issuerDID, metaBytes)
+	return err
+}
+
+// ListTrustedIssuers lists issuers trusted for a tenant.
+func (p *PGTenantTrustRegistry) ListTrustedIssuers(ctx context.Context, tenantID string) ([]string, error) {
+	const query = `SELECT issuer_did FROM tenant_trusted_issuers WHERE tenant_id = $1`
+	rows, err := p.db.QueryContext(ctx, query, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	issuers := []string{}
+	for rows.Next() {
+		var did string
+		if err := rows.Scan(&did); err != nil {
+			return nil, err
+		}
+		issuers = append(issuers, did)
+	}
+	return issuers, rows.Err()
+}

--- a/migrations/0002_add_tenants.sql
+++ b/migrations/0002_add_tenants.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS tenants (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    enabled BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tenant_trusted_issuers (
+    tenant_id TEXT NOT NULL,
+    issuer_did TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, issuer_did)
+);

--- a/test/multitenant/multitenant_test.go
+++ b/test/multitenant/multitenant_test.go
@@ -1,0 +1,139 @@
+package multitenant
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/config"
+	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/httpx"
+	"github.com/bradtumy/credential-service/internal/keystore"
+	"github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/tenant"
+)
+
+type recordingEngine struct {
+	inputs []policy.EvaluationInput
+	allow  bool
+}
+
+func (r *recordingEngine) Evaluate(input policy.EvaluationInput) (policy.EvaluationResult, error) {
+	r.inputs = append(r.inputs, input)
+	if r.allow {
+		return policy.EvaluationResult{Allow: true, Reason: "record_allow"}, nil
+	}
+	return policy.EvaluationResult{Allow: false, Reason: "record_deny"}, nil
+}
+
+func TestMultiTenantEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	tenantStore := tenant.NewMemoryStore()
+	tenants := []string{"tenant-a", "tenant-b"}
+	for _, id := range tenants {
+		if err := tenantStore.UpsertTenant(ctx, domain.Tenant{ID: id, Enabled: true}); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+
+	trustRegistry := domain.NewMemoryTrustRegistry()
+	keyStore := keystore.NewMemoryKeyStore()
+	issuerDIDs := make(map[string]string)
+	issuerKeys := make(map[string]crypto.PublicKey)
+
+	for _, tenantID := range tenants {
+		signer, err := keyStore.GetSigningKey(tenantID)
+		if err != nil {
+			t.Fatalf("get signing key: %v", err)
+		}
+		did, err := domain.DIDFromPublicKey(signer.Public())
+		if err != nil {
+			t.Fatalf("derive did: %v", err)
+		}
+		issuerDIDs[tenantID] = did
+		issuerKeys[did] = signer.Public()
+	}
+
+	if err := trustRegistry.AddTrustedIssuer(ctx, "tenant-a", issuerDIDs["tenant-a"]); err != nil {
+		t.Fatalf("trust tenant-a issuer: %v", err)
+	}
+
+	signingKeyA, err := keyStore.GetSigningKey("tenant-a")
+	if err != nil {
+		t.Fatalf("fetch signing key: %v", err)
+	}
+
+	resolver := func(issuer string) (crypto.PublicKey, error) {
+		if key, ok := issuerKeys[issuer]; ok {
+			return key, nil
+		}
+		return nil, domain.ErrUntrustedIssuer
+	}
+
+	cfg := config.IssuerConfig{DefaultTenantID: "tenant-a"}
+	policyEngine := &recordingEngine{allow: true}
+
+	mux := http.NewServeMux()
+	httpx.RegisterIssuerRoutes(mux, keyStore, cfg)
+	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policyEngine, cfg.DefaultTenantID, signingKeyA, issuerDIDs[cfg.DefaultTenantID], time.Now)
+
+	handler := httpx.RequestContext(httpx.TenantMiddleware(tenant.Resolver{Mode: tenant.ModeMulti, DefaultTenantID: cfg.DefaultTenantID, Store: tenantStore}, mux))
+
+	issuePayload := httpx.IssueRequest{SubjectDID: "did:example:alice", TTLSeconds: 600}
+	issueBody, _ := json.Marshal(issuePayload)
+	issueReq := httptest.NewRequest(http.MethodPost, "/v1/credentials/issue", bytes.NewReader(issueBody))
+	issueReq.Header.Set("X-Tenant-ID", "tenant-a")
+	issueRec := httptest.NewRecorder()
+	handler.ServeHTTP(issueRec, issueReq)
+	if issueRec.Code != http.StatusOK {
+		t.Fatalf("issue credential status: %d", issueRec.Code)
+	}
+	var issueResp httpx.IssueResponse
+	_ = json.NewDecoder(issueRec.Body).Decode(&issueResp)
+	if issueResp.Credential == "" {
+		t.Fatalf("expected credential token")
+	}
+
+	verifyPayload := httpx.VerifyRequest{Credential: issueResp.Credential}
+	verifyBody, _ := json.Marshal(verifyPayload)
+
+	verifyReq := httptest.NewRequest(http.MethodPost, "/v1/credentials/verify", bytes.NewReader(verifyBody))
+	verifyReq.Header.Set("X-Tenant-ID", "tenant-a")
+	verifyRec := httptest.NewRecorder()
+	handler.ServeHTTP(verifyRec, verifyReq)
+	if verifyRec.Code != http.StatusOK {
+		t.Fatalf("verify tenant-a status: %d", verifyRec.Code)
+	}
+
+	verifyReqB := httptest.NewRequest(http.MethodPost, "/v1/credentials/verify", bytes.NewReader(verifyBody))
+	verifyReqB.Header.Set("X-Tenant-ID", "tenant-b")
+	verifyRecB := httptest.NewRecorder()
+	handler.ServeHTTP(verifyRecB, verifyReqB)
+	if verifyRecB.Code != http.StatusForbidden {
+		t.Fatalf("verify tenant-b expected forbidden, got %d", verifyRecB.Code)
+	}
+
+	gatewayPayload := httpx.GatewayAuthorizeRequest{Credential: issueResp.Credential}
+	gatewayBody, _ := json.Marshal(gatewayPayload)
+	gatewayReq := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(gatewayBody))
+	gatewayReq.Header.Set("X-Tenant-ID", "tenant-a")
+	gatewayRec := httptest.NewRecorder()
+	handler.ServeHTTP(gatewayRec, gatewayReq)
+	if gatewayRec.Code != http.StatusOK {
+		t.Fatalf("gateway status: %d", gatewayRec.Code)
+	}
+	var gatewayResp httpx.GatewayAuthorizeResponse
+	_ = json.NewDecoder(gatewayRec.Body).Decode(&gatewayResp)
+	if gatewayResp.TenantID != "tenant-a" || !gatewayResp.Allowed {
+		t.Fatalf("unexpected gateway response: %+v", gatewayResp)
+	}
+	if len(policyEngine.inputs) == 0 || policyEngine.inputs[0].TenantID != "tenant-a" {
+		t.Fatalf("policy engine did not receive tenant context")
+	}
+}

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -63,7 +63,7 @@ func TestSmokeFlow(t *testing.T) {
 
 	verifierMux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(verifierMux, resolver, registry, issuerCfg.DefaultTenantID, time.Now)
-	httpx.RegisterGatewayRoutes(verifierMux, resolver, registry, issuerCfg.DefaultTenantID, signer, issuerDID, time.Now)
+	httpx.RegisterGatewayRoutes(verifierMux, resolver, registry, nil, issuerCfg.DefaultTenantID, signer, issuerDID, time.Now)
 	verifierServer := httptest.NewServer(verifierMux)
 	t.Cleanup(verifierServer.Close)
 


### PR DESCRIPTION
## Summary
- add tenant model, storage, resolver middleware, and database migrations to support multi-tenant operation with default single-tenant compatibility
- introduce policy engine skeleton with a no-op evaluator and thread it through gateway authorization alongside tenant-aware trust registry updates
- document tenancy and policy flows and add end-to-end multi-tenant tests with new middleware coverage

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b54dcb758832c9f9c8fb1349b7495)