### PR TITLE
Harden gateway authorize and add JWT validation utilities

### DIFF
--- a/GATEWAY_HARDENING.md
+++ b/GATEWAY_HARDENING.md
@@ -1,0 +1,26 @@
+# Gateway Hardening
+
+## Overview
+The gateway authorization endpoint (`/v1/gateway/authorize`) is the primary enforcement point for service-to-service access. It verifies delegated credentials, evaluates policy, and optionally issues synthetic JWTs for downstream compatibility.
+
+## Input Validation
+Requests are validated for presence and reasonable length of `credential` (or `credentials`), `resource`, and `action`. Empty or oversized fields are rejected with a standardized `invalid_request` API error, preserving API versioning in responses.
+
+## Synthetic JWT
+When `want_synthetic_jwt` is true, the gateway issues a short-lived token signed by the verifier. Downstream services can validate these tokens using `internal/jwtutil` helpers, which enforce issuer, audience, algorithm allow-lists, and JWKS-based signature verification.
+
+## Caching
+Authorization decisions can be cached (optionally in Redis) to reduce latency for repeated requests. Keys include tenant, credential hash, resource, action, and whether a synthetic JWT was requested. TTLs are bounded by credential expiry and a short max window to balance performance with revocation responsiveness.
+
+## Rate Limiting
+The gateway exposes a pluggable limiter interface. By default a noop limiter is used; enabling `RATELIMIT_ENABLED` allows swapping in a real backend (for example, Redis) to mitigate brute-force or abuse patterns.
+
+## Observability
+Metrics track gateway requests, allows/denies, and cache hit rates. Structured JSON logs capture tenant, subject, acting-on-behalf-of data, delegation depth, cache status, and latency without leaking credential contents.
+
+## Future Enhancements
+- Enforce mTLS between gateway and downstream services
+- Integrate IP reputation and anomaly signals
+- Place a WAF in front of the gateway for coarse filtering
+- Add redis-backed rate limiting tokens with configurable policies
+

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -11,12 +11,14 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/bradtumy/credential-service/internal/cache"
 	"github.com/bradtumy/credential-service/internal/config"
 	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
 	"github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/ratelimit"
 	"github.com/bradtumy/credential-service/internal/storage"
 	"github.com/bradtumy/credential-service/internal/tenant"
 )
@@ -84,7 +86,22 @@ func main() {
 
 	mux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
-	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policy.NoOpEngine{}, cfg.DefaultTenantID, signer, issuerDID, time.Now)
+	var decisionCache cache.DecisionCache = cache.NoopDecisionCache{}
+	if cfg.GatewayCache && cfg.RedisAddr != "" {
+		redisCache, err := cache.NewRedisDecisionCacheFromEnv()
+		if err != nil {
+			log.Printf("gateway cache disabled: %v", err)
+		} else {
+			decisionCache = redisCache
+		}
+	}
+
+	var limiter ratelimit.Limiter = ratelimit.NoopLimiter{}
+	if cfg.RateLimitEnabled {
+		log.Printf("rate limiting enabled but using noop limiter; configure backend to enforce limits")
+	}
+
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policy.NoOpEngine{}, cfg.DefaultTenantID, signer, issuerDID, decisionCache, limiter, nil, time.Now)
 	httpx.RegisterHealthRoutes(mux, readiness)
 
 	handler := httpx.RequestContext(httpx.TenantMiddleware(tenantResolver, httpx.LoggingMiddleware(mux)))

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,16 @@ module github.com/bradtumy/credential-service
 go 1.22
 
 require (
+	cloud.google.com/go/kms v1.15.0
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/bradtumy/credential-service/sdk/go v0.0.0
+	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/vault/api v1.15.0
 	github.com/jackc/pgx/v4 v4.18.3
+	github.com/lib/pq v1.10.9
+	github.com/redis/go-redis/v9 v9.17.1
 	github.com/streadway/amqp v1.1.0
 )
 
@@ -15,10 +20,9 @@ require (
 	cloud.google.com/go/compute v1.19.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.0 // indirect
-	cloud.google.com/go/kms v1.15.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -42,7 +46,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jackc/puddle v1.3.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.110.2 h1:sdFPBr6xG9/wkBbfhmUz/JmZC7X6LavQgcrVINrKiVA=
+cloud.google.com/go v0.110.2/go.mod h1:k04UEeEtb6ZBRTv3dZz4CeJC3jKGxyhl0sAiVVquxiw=
 cloud.google.com/go/compute v1.19.3 h1:DcTwsFgGev/wV5+q8o2fzgcHOaac+DKGC91ZlvpsQds=
 cloud.google.com/go/compute v1.19.3/go.mod h1:qxvISKp/gYnXkSAD1ppcSOveRAmzxicEv/JlizULFrI=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
@@ -15,10 +17,16 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -34,6 +42,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -207,6 +217,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/redis/go-redis/v9 v9.17.1 h1:7tl732FjYPRT9H9aNfyTwKg9iTETjWjGKEJ2t/5iWTs=
+github.com/redis/go-redis/v9 v9.17.1/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
@@ -300,6 +312,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,18 @@
+package cache
+
+import "time"
+
+// DecisionCache captures pluggable storage for authorization decisions.
+type DecisionCache interface {
+	Get(key string) (value []byte, ok bool, err error)
+	Set(key string, value []byte, ttl time.Duration) error
+}
+
+// NoopDecisionCache is a disabled cache implementation.
+type NoopDecisionCache struct{}
+
+// Get always returns a cache miss.
+func (NoopDecisionCache) Get(key string) ([]byte, bool, error) { return nil, false, nil }
+
+// Set is a no-op.
+func (NoopDecisionCache) Set(key string, value []byte, ttl time.Duration) error { return nil }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,15 @@
+package cache
+
+import "testing"
+
+func TestNoopDecisionCache(t *testing.T) {
+	cache := NoopDecisionCache{}
+
+	if _, ok, err := cache.Get("key"); err != nil || ok {
+		t.Fatalf("expected miss without error, got ok=%v err=%v", ok, err)
+	}
+
+	if err := cache.Set("key", []byte("value"), 0); err != nil {
+		t.Fatalf("expected no error on set: %v", err)
+	}
+}

--- a/internal/cache/redis_cache.go
+++ b/internal/cache/redis_cache.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisDecisionCache implements DecisionCache backed by Redis.
+type RedisDecisionCache struct {
+	client *redis.Client
+}
+
+// NewRedisDecisionCacheFromEnv initializes a RedisDecisionCache using standard env vars.
+func NewRedisDecisionCacheFromEnv() (*RedisDecisionCache, error) {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		return nil, errors.New("REDIS_ADDR is required")
+	}
+
+	db := 0
+	if dbStr := os.Getenv("REDIS_DB"); dbStr != "" {
+		parsed, err := strconv.Atoi(dbStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse REDIS_DB: %w", err)
+		}
+		db = parsed
+	}
+
+	client := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: os.Getenv("REDIS_PASSWORD"),
+		DB:       db,
+	})
+
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("ping redis: %w", err)
+	}
+
+	return &RedisDecisionCache{client: client}, nil
+}
+
+// Get retrieves a cached value.
+func (r *RedisDecisionCache) Get(key string) ([]byte, bool, error) {
+	if r == nil || r.client == nil {
+		return nil, false, errors.New("redis client not configured")
+	}
+	res, err := r.client.Get(context.Background(), key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return res, true, nil
+}
+
+// Set stores a value with TTL.
+func (r *RedisDecisionCache) Set(key string, value []byte, ttl time.Duration) error {
+	if r == nil || r.client == nil {
+		return errors.New("redis client not configured")
+	}
+	return r.client.Set(context.Background(), key, value, ttl).Err()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 )
 
 // Config holds application configuration loaded from environment variables.
@@ -39,40 +40,60 @@ func getenv(key, fallback string) string {
 
 // IssuerConfig holds configuration for the issuer service.
 type IssuerConfig struct {
-        HTTPPort        string
-        DefaultTenantID string
-        TenancyMode     string
-        LogLevel        string
+	HTTPPort        string
+	DefaultTenantID string
+	TenancyMode     string
+	LogLevel        string
 }
 
 // LoadIssuerConfigFromEnv loads issuer configuration from environment variables.
 func LoadIssuerConfigFromEnv() IssuerConfig {
-        return IssuerConfig{
-                HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
-                DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
-                TenancyMode:     getenv("TENANCY_MODE", "single"),
-                LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
-        }
+	return IssuerConfig{
+		HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
+		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		TenancyMode:     getenv("TENANCY_MODE", "single"),
+		LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
+	}
 }
 
 // VerifierConfig holds configuration for the verifier service.
 type VerifierConfig struct {
-        HTTPPort           string
-        DefaultTenantID    string
-        DB_DSN             string
-        UseDBTrustRegistry bool
-        TenancyMode        string
-        LogLevel           string
+	HTTPPort           string
+	DefaultTenantID    string
+	DB_DSN             string
+	UseDBTrustRegistry bool
+	TenancyMode        string
+	LogLevel           string
+	GatewayCache       bool
+	RateLimitEnabled   bool
+	RedisAddr          string
+	RedisPassword      string
+	RedisDB            int
 }
 
 // LoadVerifierConfigFromEnv loads verifier configuration from environment variables.
 func LoadVerifierConfigFromEnv() VerifierConfig {
-        return VerifierConfig{
-                HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
-                DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
-                DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
-                UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
-                TenancyMode:        getenv("TENANCY_MODE", "single"),
-                LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
-        }
+	return VerifierConfig{
+		HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
+		DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
+		UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
+		TenancyMode:        getenv("TENANCY_MODE", "single"),
+		LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
+		GatewayCache:       getenv("GATEWAY_CACHE_ENABLED", "false") == "true",
+		RateLimitEnabled:   getenv("RATELIMIT_ENABLED", "false") == "true",
+		RedisAddr:          getenv("REDIS_ADDR", ""),
+		RedisPassword:      getenv("REDIS_PASSWORD", ""),
+		RedisDB:            getenvInt("REDIS_DB", 0),
+	}
+}
+
+func getenvInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,6 +51,11 @@ func TestLoadVerifierConfigFromEnvDefaults(t *testing.T) {
 	t.Setenv("VERIFIER_DB_DSN", "")
 	t.Setenv("VERIFIER_USE_DB_TRUST_REGISTRY", "")
 	t.Setenv("VERIFIER_LOG_LEVEL", "")
+	t.Setenv("GATEWAY_CACHE_ENABLED", "")
+	t.Setenv("RATELIMIT_ENABLED", "")
+	t.Setenv("REDIS_ADDR", "")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DB", "")
 
 	cfg := LoadVerifierConfigFromEnv()
 
@@ -72,6 +77,15 @@ func TestLoadVerifierConfigFromEnvDefaults(t *testing.T) {
 	if cfg.LogLevel != "info" {
 		t.Fatalf("expected default log level info, got %s", cfg.LogLevel)
 	}
+	if cfg.GatewayCache {
+		t.Fatalf("expected gateway cache disabled by default")
+	}
+	if cfg.RateLimitEnabled {
+		t.Fatalf("expected rate limiting disabled by default")
+	}
+	if cfg.RedisAddr != "" || cfg.RedisPassword != "" || cfg.RedisDB != 0 {
+		t.Fatalf("expected redis settings to be empty by default")
+	}
 }
 
 func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
@@ -81,6 +95,11 @@ func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("VERIFIER_USE_DB_TRUST_REGISTRY", "true")
 	t.Setenv("VERIFIER_LOG_LEVEL", "warn")
 	t.Setenv("TENANCY_MODE", "multi")
+	t.Setenv("GATEWAY_CACHE_ENABLED", "true")
+	t.Setenv("RATELIMIT_ENABLED", "true")
+	t.Setenv("REDIS_ADDR", "redis:6379")
+	t.Setenv("REDIS_PASSWORD", "secret")
+	t.Setenv("REDIS_DB", "2")
 
 	cfg := LoadVerifierConfigFromEnv()
 
@@ -101,5 +120,14 @@ func TestLoadVerifierConfigFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.LogLevel != "warn" {
 		t.Fatalf("expected warn log level, got %s", cfg.LogLevel)
+	}
+	if !cfg.GatewayCache {
+		t.Fatalf("expected gateway cache enabled")
+	}
+	if !cfg.RateLimitEnabled {
+		t.Fatalf("expected rate limiting enabled")
+	}
+	if cfg.RedisAddr != "redis:6379" || cfg.RedisPassword != "secret" || cfg.RedisDB != 2 {
+		t.Fatalf("expected redis settings to propagate, got %+v", cfg)
 	}
 }

--- a/internal/httpx/gateway_handlers.go
+++ b/internal/httpx/gateway_handlers.go
@@ -2,15 +2,20 @@ package httpx
 
 import (
 	"crypto"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
+	"github.com/bradtumy/credential-service/internal/cache"
 	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/logging"
 	"github.com/bradtumy/credential-service/internal/metrics"
 	"github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/ratelimit"
 	"github.com/bradtumy/credential-service/internal/version"
 )
 
@@ -20,6 +25,8 @@ type GatewayAuthorizeRequest struct {
 	Credentials      []string `json:"credentials"`
 	ExpectedAudience string   `json:"expected_audience"`
 	WantSyntheticJWT bool     `json:"want_synthetic_jwt"`
+	Resource         string   `json:"resource"`
+	Action           string   `json:"action"`
 }
 
 // GatewayAuthorizeResponse is returned to gateways or reverse proxies.
@@ -43,8 +50,25 @@ type AgentContext struct {
 	Scope            []string `json:"scope,omitempty"`
 }
 
+const (
+	maxCredentialLength = 8192
+	maxFieldLength      = 512
+)
+
 // RegisterGatewayRoutes wires gateway-specific routes into the provided mux.
-func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.PublicKey, error), registry domain.TrustRegistry, policyEngine policy.Engine, defaultTenantID string, signingKey crypto.Signer, jwtIssuer string, now func() time.Time) {
+func RegisterGatewayRoutes(
+	mux *http.ServeMux,
+	resolver func(string) (crypto.PublicKey, error),
+	registry domain.TrustRegistry,
+	policyEngine policy.Engine,
+	defaultTenantID string,
+	signingKey crypto.Signer,
+	jwtIssuer string,
+	decisionCache cache.DecisionCache,
+	limiter ratelimit.Limiter,
+	gwMetrics metrics.GatewayMetrics,
+	now func() time.Time,
+) {
 	if now == nil {
 		now = time.Now
 	}
@@ -53,7 +77,20 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		policyEngine = policy.NoOpEngine{}
 	}
 
+	if decisionCache == nil {
+		decisionCache = cache.NoopDecisionCache{}
+	}
+
+	if limiter == nil {
+		limiter = ratelimit.NoopLimiter{}
+	}
+
+	if gwMetrics == nil {
+		gwMetrics = metrics.DefaultGatewayMetrics
+	}
+
 	mux.HandleFunc("/v1/gateway/authorize", func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
 		if r.Method != http.MethodPost {
 			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 			return
@@ -65,20 +102,48 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			return
 		}
 
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = defaultTenantID
+		}
+
+		gwMetrics.IncAuthzRequest(tenantID)
+
+		if err := validateGatewayRequest(req); err != nil {
+			gwMetrics.IncAuthzDeny(tenantID, "invalid_request")
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+
 		tokens := req.Credentials
 		if len(tokens) == 0 && req.Credential != "" {
 			tokens = []string{req.Credential}
 		}
 
-		if len(tokens) == 0 {
-			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "credential is required")
+		rateKey := buildRateLimitKey(r.RemoteAddr, tenantID)
+		allowed, err := limiter.Allow(rateKey)
+		if err != nil {
+			logging.Logger.With("error", err.Error(), "tenant_id", tenantID).Warn("rate limit check error")
+		}
+		if !allowed {
+			gwMetrics.IncAuthzDeny(tenantID, "rate_limited")
+			WriteAPIError(w, http.StatusTooManyRequests, "rate_limited", "rate limit exceeded")
 			return
 		}
 
-		tenantID := TenantIDFromContext(r.Context())
-		if tenantID == "" {
-			tenantID = defaultTenantID
+		cacheKey := buildCacheKey(tokens, tenantID, req.Resource, req.Action, req.ExpectedAudience, req.WantSyntheticJWT)
+		if cached, ok := readCachedDecision(decisionCache, cacheKey); ok {
+			gwMetrics.IncAuthzCacheHit(tenantID)
+			logGatewayDecision(started, tenantID, cached, true)
+			writeDecision(w, cached)
+			if cached.Allowed {
+				gwMetrics.IncAuthzAllow(tenantID)
+			} else {
+				gwMetrics.IncAuthzDeny(tenantID, cached.Reason)
+			}
+			return
 		}
+		gwMetrics.IncAuthzCacheMiss(tenantID)
 
 		deps := domain.VerifierDependencies{ResolveIssuerPublicKey: func(issuer string) (crypto.PublicKey, error) {
 			if registry != nil {
@@ -100,7 +165,10 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		if err != nil {
 			reason := mapVerificationErrorToReason(err)
 			metrics.DefaultVerifierMetrics.IncVerificationFailure(reason)
-			writeDecision(w, GatewayAuthorizeResponse{Allowed: false, Reason: reason, APIVersion: version.APIVersion})
+			resp := GatewayAuthorizeResponse{Allowed: false, Reason: reason, APIVersion: version.APIVersion, TenantID: tenantID}
+			gwMetrics.IncAuthzDeny(tenantID, reason)
+			logGatewayDecision(started, tenantID, resp, false)
+			writeDecision(w, resp)
 			return
 		}
 
@@ -111,8 +179,8 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			ActingOnBehalfOf: decision.ActingOnBehalfOf,
 			Scope:            domain.ScopeFromClaims(decision.Claims),
 			Claims:           decision.Claims,
-			Resource:         req.ExpectedAudience,
-			Action:           "gateway_authorize",
+			Resource:         req.Resource,
+			Action:           req.Action,
 			Context: map[string]any{
 				"delegation_depth": chainResult.DelegationDepth,
 				"path":             r.URL.Path,
@@ -125,6 +193,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			return
 		}
 		if !policyResult.Allow {
+			gwMetrics.IncAuthzDeny(tenantID, "policy_denied")
 			WriteAPIError(w, http.StatusForbidden, "policy_denied", policyResult.Reason)
 			return
 		}
@@ -145,7 +214,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 			Subject:          decision.SubjectDID,
 			ActingOnBehalfOf: decision.ActingOnBehalfOf,
 			DelegationDepth:  decision.DelegationDepth,
-			Claims:           decision.Claims,
+			Claims:           filterSafeClaims(decision.Claims),
 			Reason:           decision.Reason,
 			Agent:            agentContext,
 			TenantID:         tenantID,
@@ -155,13 +224,19 @@ func RegisterGatewayRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pub
 		if req.WantSyntheticJWT {
 			jwt, err := domain.BuildSyntheticJWT(decision, signingKey, jwtIssuer, 15*time.Minute)
 			if err != nil {
-				writeDecision(w, GatewayAuthorizeResponse{Allowed: false, Reason: "jwt_error", APIVersion: version.APIVersion})
+				resp := GatewayAuthorizeResponse{Allowed: false, Reason: "jwt_error", APIVersion: version.APIVersion, TenantID: tenantID}
+				gwMetrics.IncAuthzDeny(tenantID, "jwt_error")
+				writeDecision(w, resp)
 				return
 			}
 			response.SyntheticJWT = jwt.Token
 		}
 
 		metrics.DefaultVerifierMetrics.IncVerificationSuccess("ok")
+		gwMetrics.IncAuthzAllow(tenantID)
+		ttl := computeDecisionTTL(chainResult, now())
+		persistDecision(decisionCache, cacheKey, response, ttl)
+		logGatewayDecision(started, tenantID, response, false)
 		writeDecision(w, response)
 	})
 }
@@ -195,4 +270,137 @@ func mapVerificationErrorToReason(err error) string {
 	default:
 		return "verification_failed"
 	}
+}
+
+func validateGatewayRequest(req GatewayAuthorizeRequest) error {
+	tokens := req.Credentials
+	if len(tokens) == 0 && req.Credential != "" {
+		tokens = []string{req.Credential}
+	}
+
+	if len(tokens) == 0 {
+		return fmt.Errorf("credential is required")
+	}
+
+	if len(req.Resource) == 0 {
+		return fmt.Errorf("resource is required")
+	}
+	if len(req.Action) == 0 {
+		return fmt.Errorf("action is required")
+	}
+
+	if len(req.ExpectedAudience) > maxFieldLength || len(req.Resource) > maxFieldLength || len(req.Action) > maxFieldLength {
+		return fmt.Errorf("input fields too long")
+	}
+
+	for _, token := range tokens {
+		if token == "" {
+			return fmt.Errorf("credential cannot be empty")
+		}
+		if len(token) > maxCredentialLength {
+			return fmt.Errorf("credential too large")
+		}
+	}
+
+	return nil
+}
+
+func filterSafeClaims(claims map[string]interface{}) map[string]interface{} {
+	if claims == nil {
+		return nil
+	}
+	safe := map[string]interface{}{}
+	if scope, ok := claims["scope"]; ok {
+		safe["scope"] = scope
+	}
+	if roles, ok := claims["roles"]; ok {
+		safe["roles"] = roles
+	}
+	if len(safe) == 0 {
+		return nil
+	}
+	return safe
+}
+
+func buildCacheKey(tokens []string, tenantID, resource, action, expectedAudience string, wantSynthetic bool) string {
+	h := sha256.New()
+	for _, token := range tokens {
+		_, _ = h.Write([]byte(token))
+	}
+	_, _ = h.Write([]byte(tenantID))
+	_, _ = h.Write([]byte(resource))
+	_, _ = h.Write([]byte(action))
+	_, _ = h.Write([]byte(expectedAudience))
+	if wantSynthetic {
+		h.Write([]byte("synthetic"))
+	}
+	return fmt.Sprintf("gw:%x", h.Sum(nil))
+}
+
+func readCachedDecision(decisionCache cache.DecisionCache, key string) (GatewayAuthorizeResponse, bool) {
+	if decisionCache == nil {
+		return GatewayAuthorizeResponse{}, false
+	}
+
+	data, ok, err := decisionCache.Get(key)
+	if err != nil || !ok {
+		return GatewayAuthorizeResponse{}, false
+	}
+
+	var resp GatewayAuthorizeResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return GatewayAuthorizeResponse{}, false
+	}
+	return resp, true
+}
+
+func persistDecision(decisionCache cache.DecisionCache, key string, resp GatewayAuthorizeResponse, ttl time.Duration) {
+	if decisionCache == nil || ttl <= 0 {
+		return
+	}
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	_ = decisionCache.Set(key, payload, ttl)
+}
+
+func computeDecisionTTL(chainResult *domain.DelegationChainResult, now time.Time) time.Duration {
+	defaultTTL := 60 * time.Second
+	if chainResult == nil || len(chainResult.Credentials) == 0 {
+		return defaultTTL
+	}
+	leaf := chainResult.Credentials[len(chainResult.Credentials)-1]
+	if leaf.ExpiresAt.IsZero() {
+		return defaultTTL
+	}
+	remaining := leaf.ExpiresAt.Sub(now)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < defaultTTL {
+		return remaining
+	}
+	return defaultTTL
+}
+
+func buildRateLimitKey(remoteAddr, tenantID string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	return fmt.Sprintf("%s:%s", tenantID, host)
+}
+
+func logGatewayDecision(started time.Time, tenantID string, resp GatewayAuthorizeResponse, cacheHit bool) {
+	latency := time.Since(started)
+	logging.Logger.With(
+		"tenant_id", tenantID,
+		"subject", resp.Subject,
+		"acting_on_behalf_of", resp.ActingOnBehalfOf,
+		"delegation_depth", resp.DelegationDepth,
+		"allowed", resp.Allowed,
+		"cache_hit", cacheHit,
+		"latency_ms", latency.Milliseconds(),
+	).Info("gateway_authorize")
 }

--- a/internal/httpx/gateway_handlers_test.go
+++ b/internal/httpx/gateway_handlers_test.go
@@ -35,9 +35,9 @@ func TestGatewayAuthorizeAllow(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
 
-	payload := GatewayAuthorizeRequest{Credential: token, WantSyntheticJWT: true}
+	payload := GatewayAuthorizeRequest{Credential: token, WantSyntheticJWT: true, Resource: "orders", Action: "read"}
 	body, _ := json.Marshal(payload)
 
 	rr := httptest.NewRecorder()
@@ -82,9 +82,9 @@ func TestGatewayAuthorizeAgentContext(t *testing.T) {
 	childToken, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 2*time.Minute, map[string]interface{}{"scope": []string{"read"}})
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
 
-	payload := GatewayAuthorizeRequest{Credentials: []string{parentToken, childToken}, WantSyntheticJWT: true}
+	payload := GatewayAuthorizeRequest{Credentials: []string{parentToken, childToken}, WantSyntheticJWT: true, Resource: "orders", Action: "read"}
 	body, _ := json.Marshal(payload)
 
 	rr := httptest.NewRecorder()
@@ -129,11 +129,11 @@ func TestGatewayAuthorizeDenyExpired(t *testing.T) {
 	cred := decodeCredentialForHandlerTest(t, token)
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, func() time.Time {
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, nil, nil, nil, func() time.Time {
 		return cred.ExpiresAt.Add(time.Second)
 	})
 
-	payload := GatewayAuthorizeRequest{Credential: token}
+	payload := GatewayAuthorizeRequest{Credential: token, Resource: "orders", Action: "read"}
 	body, _ := json.Marshal(payload)
 
 	rr := httptest.NewRecorder()
@@ -168,9 +168,9 @@ func TestGatewayAuthorizeUntrustedIssuer(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, time.Now)
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
 
-	payload := GatewayAuthorizeRequest{Credential: token}
+	payload := GatewayAuthorizeRequest{Credential: token, Resource: "orders", Action: "read"}
 	body, _ := json.Marshal(payload)
 
 	rr := httptest.NewRecorder()
@@ -187,4 +187,160 @@ func TestGatewayAuthorizeUntrustedIssuer(t *testing.T) {
 	if resp.Allowed || resp.Reason != "untrusted_issuer" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
+}
+
+func TestGatewayAuthorizeMissingCredential(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", nil, nil, nil, time.Now)
+
+	payload := GatewayAuthorizeRequest{Resource: "orders", Action: "read"}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestGatewayAuthorizeMissingResource(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", nil, nil, nil, time.Now)
+
+	payload := GatewayAuthorizeRequest{Credential: "token", Action: "read"}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestGatewayAuthorizeRateLimited(t *testing.T) {
+	limiter := &stubLimiter{allow: false}
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", nil, limiter, nil, time.Now)
+
+	payload := GatewayAuthorizeRequest{Credential: "token", Resource: "orders", Action: "read"}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rr.Code)
+	}
+}
+
+func TestGatewayAuthorizeCacheHitSkipsVerification(t *testing.T) {
+	cache := &recordingCache{}
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", cache, nil, nil, time.Now)
+
+	// Prime cache with allowed decision.
+	cached := GatewayAuthorizeResponse{Allowed: true, Subject: "did:example:cached", TenantID: "tenant", APIVersion: version.APIVersion}
+	key := buildCacheKey([]string{"cached-token"}, "tenant", "orders", "read", "", false)
+	payload, _ := json.Marshal(cached)
+	_ = cache.Set(key, payload, time.Minute)
+
+	reqBody, _ := json.Marshal(GatewayAuthorizeRequest{Credential: "cached-token", Resource: "orders", Action: "read"})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(reqBody))
+
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	if cache.getCalls == 0 {
+		t.Fatalf("expected cache get to be invoked")
+	}
+}
+
+func TestGatewayAuthorizeCachesDecision(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+	registry := domain.NewMemoryTrustRegistry()
+	registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
+
+	resolverCalls := 0
+	resolver := func(issuer string) (crypto.PublicKey, error) {
+		resolverCalls++
+		return priv.Public(), nil
+	}
+
+	token, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 5*time.Minute, map[string]interface{}{"scope": "read:orders"})
+
+	cache := &recordingCache{}
+	mux := http.NewServeMux()
+	RegisterGatewayRoutes(mux, resolver, registry, nil, "tenant", priv, issuerDID, cache, nil, nil, time.Now)
+
+	body, _ := json.Marshal(GatewayAuthorizeRequest{Credential: token, Resource: "orders", Action: "read"})
+
+	// First request populates cache.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+	mux.ServeHTTP(rr, req)
+
+	if cache.setCalls == 0 {
+		t.Fatalf("expected cache set to be invoked")
+	}
+
+	resolverCallsAfterFirst := resolverCalls
+
+	// Second request should hit cache and avoid resolver.
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+	mux.ServeHTTP(rr2, req2)
+
+	if resolverCalls != resolverCallsAfterFirst {
+		t.Fatalf("expected resolver calls to remain constant on cache hit")
+	}
+}
+
+type stubLimiter struct {
+	allow bool
+}
+
+func (s *stubLimiter) Allow(string) (bool, error) {
+	return s.allow, nil
+}
+
+type recordingCache struct {
+	stored   map[string][]byte
+	getCalls int
+	setCalls int
+}
+
+func (c *recordingCache) Get(key string) ([]byte, bool, error) {
+	c.getCalls++
+	if c.stored == nil {
+		return nil, false, nil
+	}
+	val, ok := c.stored[key]
+	if !ok {
+		return nil, false, nil
+	}
+	return val, true, nil
+}
+
+func (c *recordingCache) Set(key string, value []byte, ttl time.Duration) error {
+	_ = ttl
+	if c.stored == nil {
+		c.stored = map[string][]byte{}
+	}
+	c.stored[key] = value
+	c.setCalls++
+	return nil
 }

--- a/internal/jwtutil/jwtutil.go
+++ b/internal/jwtutil/jwtutil.go
@@ -1,0 +1,181 @@
+package jwtutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// ValidationConfig controls how synthetic JWTs are validated.
+type ValidationConfig struct {
+	Issuer      string
+	Audience    string
+	AllowedAlgs []string
+	JWKSURL     string
+}
+
+// Claims captures a parsed synthetic JWT in a safe structure.
+type Claims struct {
+	Subject         string
+	OnBehalfOf      string
+	Scope           []string
+	DelegationDepth int
+	Raw             map[string]any
+}
+
+// ValidateSyntheticJWT verifies a synthetic JWT against the provided configuration.
+func ValidateSyntheticJWT(token string, cfg ValidationConfig) (*Claims, error) {
+	if token == "" {
+		return nil, errors.New("token is required")
+	}
+	if cfg.JWKSURL == "" {
+		return nil, errors.New("jwks url is required")
+	}
+	algs := parseAllowedAlgorithms(cfg.AllowedAlgs)
+	parsed, err := jwt.ParseSigned(token, algs)
+	if err != nil {
+		return nil, fmt.Errorf("parse token: %w", err)
+	}
+	if len(parsed.Headers) == 0 {
+		return nil, errors.New("missing token header")
+	}
+
+	alg := string(parsed.Headers[0].Algorithm)
+	if !isAlgAllowed(alg, cfg.AllowedAlgs) {
+		return nil, fmt.Errorf("algorithm not allowed: %s", alg)
+	}
+
+	jwks, err := fetchJWKS(cfg.JWKSURL)
+	if err != nil {
+		return nil, fmt.Errorf("load jwks: %w", err)
+	}
+
+	key, err := selectVerificationKey(jwks, parsed.Headers[0].KeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	var stdClaims jwt.Claims
+	var custom struct {
+		OnBehalfOf      string `json:"obo"`
+		Scope           any    `json:"scope"`
+		DelegationDepth int    `json:"delegation_depth"`
+	}
+	raw := map[string]any{}
+
+	if err := parsed.Claims(key, &stdClaims, &custom, &raw); err != nil {
+		return nil, fmt.Errorf("verify token: %w", err)
+	}
+
+	expected := jwt.Expected{Issuer: cfg.Issuer}
+	if cfg.Audience != "" {
+		expected.AnyAudience = jwt.Audience{cfg.Audience}
+	}
+
+	if err := stdClaims.ValidateWithLeeway(expected, time.Minute); err != nil {
+		return nil, fmt.Errorf("claim validation: %w", err)
+	}
+
+	return &Claims{
+		Subject:         stdClaims.Subject,
+		OnBehalfOf:      custom.OnBehalfOf,
+		Scope:           normalizeScope(custom.Scope),
+		DelegationDepth: custom.DelegationDepth,
+		Raw:             raw,
+	}, nil
+}
+
+func isAlgAllowed(alg string, allowed []string) bool {
+	if alg == "" {
+		return false
+	}
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, a := range allowed {
+		if a == alg {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchJWKS(url string) (*jose.JSONWebKeySet, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var jwks jose.JSONWebKeySet
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, fmt.Errorf("decode jwks: %w", err)
+	}
+
+	return &jwks, nil
+}
+
+func selectVerificationKey(set *jose.JSONWebKeySet, kid string) (any, error) {
+	if set == nil {
+		return nil, errors.New("jwks not provided")
+	}
+
+	keys := set.Key(kid)
+	if len(keys) == 0 && kid == "" {
+		keys = set.Keys
+	}
+	for _, key := range keys {
+		if key.Valid() {
+			return key.Key, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no valid key found for kid %s", kid)
+}
+
+func normalizeScope(val any) []string {
+	switch v := val.(type) {
+	case nil:
+		return nil
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if item != "" {
+				out = append(out, item)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func parseAllowedAlgorithms(algs []string) []jose.SignatureAlgorithm {
+	if len(algs) == 0 {
+		return nil
+	}
+	res := make([]jose.SignatureAlgorithm, 0, len(algs))
+	for _, alg := range algs {
+		res = append(res, jose.SignatureAlgorithm(alg))
+	}
+	return res
+}

--- a/internal/jwtutil/jwtutil_test.go
+++ b/internal/jwtutil/jwtutil_test.go
@@ -1,0 +1,108 @@
+package jwtutil
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+func TestValidateSyntheticJWTHappyPath(t *testing.T) {
+	token, jwksURL, _ := buildTestToken(t, "did:example:issuer", "api", "kid-1")
+
+	claims, err := ValidateSyntheticJWT(token, ValidationConfig{
+		Issuer:      "did:example:issuer",
+		Audience:    "api",
+		AllowedAlgs: []string{"EdDSA"},
+		JWKSURL:     jwksURL,
+	})
+	if err != nil {
+		t.Fatalf("expected token to validate: %v", err)
+	}
+
+	if claims.Subject != "did:example:subject" {
+		t.Fatalf("unexpected subject: %s", claims.Subject)
+	}
+	if claims.OnBehalfOf != "did:example:obo" {
+		t.Fatalf("unexpected obo: %s", claims.OnBehalfOf)
+	}
+	if claims.DelegationDepth != 2 {
+		t.Fatalf("unexpected delegation depth: %d", claims.DelegationDepth)
+	}
+	if len(claims.Scope) != 2 || claims.Scope[0] != "read" {
+		t.Fatalf("unexpected scope: %+v", claims.Scope)
+	}
+}
+
+func TestValidateSyntheticJWTSignatureFailure(t *testing.T) {
+	token, _, _ := buildTestToken(t, "did:example:issuer", "api", "kid-1")
+
+	// JWKS without the correct key should cause verification failure.
+	_, otherPriv, _ := ed25519.GenerateKey(nil)
+	otherPub := otherPriv.Public()
+	otherSet := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{KeyID: "kid-2", Key: otherPub, Algorithm: string(jose.EdDSA)}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(otherSet)
+	}))
+	defer srv.Close()
+
+	if _, err := ValidateSyntheticJWT(token, ValidationConfig{Issuer: "did:example:issuer", Audience: "api", AllowedAlgs: []string{"EdDSA"}, JWKSURL: srv.URL}); err == nil {
+		t.Fatalf("expected signature verification error")
+	}
+}
+
+func TestValidateSyntheticJWTWrongIssuer(t *testing.T) {
+	token, jwksURL, _ := buildTestToken(t, "did:example:issuer", "api", "kid-1")
+	if _, err := ValidateSyntheticJWT(token, ValidationConfig{Issuer: "did:example:other", Audience: "api", AllowedAlgs: []string{"EdDSA"}, JWKSURL: jwksURL}); err == nil {
+		t.Fatalf("expected issuer validation error")
+	}
+}
+
+func TestValidateSyntheticJWTDisallowedAlg(t *testing.T) {
+	token, jwksURL, _ := buildTestToken(t, "did:example:issuer", "api", "kid-1")
+	if _, err := ValidateSyntheticJWT(token, ValidationConfig{Issuer: "did:example:issuer", Audience: "api", AllowedAlgs: []string{"RS256"}, JWKSURL: jwksURL}); err == nil {
+		t.Fatalf("expected algorithm restriction error")
+	}
+}
+
+func buildTestToken(t *testing.T, issuer, aud, kid string) (string, string, ed25519.PrivateKey) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{KeyID: kid, Key: pub, Algorithm: string(jose.EdDSA)}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(set)
+	}))
+
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: jose.JSONWebKey{KeyID: kid, Key: priv}}, nil)
+	if err != nil {
+		t.Fatalf("create signer: %v", err)
+	}
+
+	claims := map[string]any{
+		"iss":              issuer,
+		"sub":              "did:example:subject",
+		"aud":              aud,
+		"exp":              time.Now().Add(time.Hour).Unix(),
+		"iat":              time.Now().Add(-time.Minute).Unix(),
+		"obo":              "did:example:obo",
+		"scope":            []string{"read", "write"},
+		"delegation_depth": 2,
+	}
+
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("serialize token: %v", err)
+	}
+
+	return token, srv.URL, priv
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -17,3 +17,33 @@ func (NoopVerifierMetrics) IncVerificationFailure(reason string) {}
 
 // DefaultVerifierMetrics is the global metrics collector for the verifier.
 var DefaultVerifierMetrics VerifierMetrics = NoopVerifierMetrics{}
+
+// GatewayMetrics describes counters for gateway authorization flow.
+type GatewayMetrics interface {
+	IncAuthzRequest(tenantID string)
+	IncAuthzAllow(tenantID string)
+	IncAuthzDeny(tenantID string, reason string)
+	IncAuthzCacheHit(tenantID string)
+	IncAuthzCacheMiss(tenantID string)
+}
+
+// NoopGatewayMetrics is a placeholder implementation.
+type NoopGatewayMetrics struct{}
+
+// IncAuthzRequest implements GatewayMetrics.
+func (NoopGatewayMetrics) IncAuthzRequest(string) {}
+
+// IncAuthzAllow implements GatewayMetrics.
+func (NoopGatewayMetrics) IncAuthzAllow(string) {}
+
+// IncAuthzDeny implements GatewayMetrics.
+func (NoopGatewayMetrics) IncAuthzDeny(string, string) {}
+
+// IncAuthzCacheHit implements GatewayMetrics.
+func (NoopGatewayMetrics) IncAuthzCacheHit(string) {}
+
+// IncAuthzCacheMiss implements GatewayMetrics.
+func (NoopGatewayMetrics) IncAuthzCacheMiss(string) {}
+
+// DefaultGatewayMetrics is the global metrics collector for gateway-specific stats.
+var DefaultGatewayMetrics GatewayMetrics = NoopGatewayMetrics{}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,12 @@
+package ratelimit
+
+// Limiter controls request admission.
+type Limiter interface {
+	Allow(key string) (bool, error)
+}
+
+// NoopLimiter always allows requests.
+type NoopLimiter struct{}
+
+// Allow always returns true.
+func (NoopLimiter) Allow(key string) (bool, error) { return true, nil }

--- a/test/multitenant/multitenant_test.go
+++ b/test/multitenant/multitenant_test.go
@@ -81,7 +81,7 @@ func TestMultiTenantEndToEnd(t *testing.T) {
 	mux := http.NewServeMux()
 	httpx.RegisterIssuerRoutes(mux, keyStore, cfg)
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, time.Now)
-	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policyEngine, cfg.DefaultTenantID, signingKeyA, issuerDIDs[cfg.DefaultTenantID], time.Now)
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policyEngine, cfg.DefaultTenantID, signingKeyA, issuerDIDs[cfg.DefaultTenantID], nil, nil, nil, time.Now)
 
 	handler := httpx.RequestContext(httpx.TenantMiddleware(tenant.Resolver{Mode: tenant.ModeMulti, DefaultTenantID: cfg.DefaultTenantID, Store: tenantStore}, mux))
 
@@ -119,7 +119,7 @@ func TestMultiTenantEndToEnd(t *testing.T) {
 		t.Fatalf("verify tenant-b expected forbidden, got %d", verifyRecB.Code)
 	}
 
-	gatewayPayload := httpx.GatewayAuthorizeRequest{Credential: issueResp.Credential}
+	gatewayPayload := httpx.GatewayAuthorizeRequest{Credential: issueResp.Credential, Resource: "sample-api", Action: "invoke"}
 	gatewayBody, _ := json.Marshal(gatewayPayload)
 	gatewayReq := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(gatewayBody))
 	gatewayReq.Header.Set("X-Tenant-ID", "tenant-a")

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -63,7 +63,7 @@ func TestSmokeFlow(t *testing.T) {
 
 	verifierMux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(verifierMux, resolver, registry, issuerCfg.DefaultTenantID, time.Now)
-	httpx.RegisterGatewayRoutes(verifierMux, resolver, registry, nil, issuerCfg.DefaultTenantID, signer, issuerDID, time.Now)
+	httpx.RegisterGatewayRoutes(verifierMux, resolver, registry, nil, issuerCfg.DefaultTenantID, signer, issuerDID, nil, nil, nil, time.Now)
 	verifierServer := httptest.NewServer(verifierMux)
 	t.Cleanup(verifierServer.Close)
 
@@ -71,6 +71,8 @@ func TestSmokeFlow(t *testing.T) {
 		Credentials:      []string{parentCred, delegated},
 		ExpectedAudience: "sample-api",
 		WantSyntheticJWT: true,
+		Resource:         "sample-api",
+		Action:           "invoke",
 	}
 	body, _ := json.Marshal(authzPayload)
 


### PR DESCRIPTION
## Summary
- add reusable synthetic JWT validation helpers for downstream services
- harden gateway authorize with input validation, caching hooks, rate limiting, and richer metrics/logging
- introduce optional Redis decision cache, rate-limit interfaces, and documentation for gateway hardening

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b57fe483c832cb735b85a4ce63c6b)