### PR TITLE
Implement policy engine v1 with admin APIs

### DIFF
--- a/POLICY_ENGINE.md
+++ b/POLICY_ENGINE.md
@@ -1,27 +1,83 @@
-# Policy Engine Skeleton
+# Policy Engine v1
 
-The policy engine evaluates authorization decisions after credentials are verified and the tenant is resolved. Day 12 ships a no-op engine to keep behavior backward compatible while establishing the contract for future ABAC/RBAC and delegation-aware policies.
+The policy engine evaluates authorization decisions after credentials are verified and the tenant is resolved. Version 1 introduces a hybrid RBAC/ABAC model with tenant-scoped policies stored in Postgres (or the in-memory store for tests and local development).
 
 ## Input Model
-- `TenantID`: Tenant derived from `X-Tenant-ID` or the default tenant in single-tenant mode
-- `Subject`: DID of the acting subject
-- `ActingOnBehalfOf`: Delegation chain root (if applicable)
-- `Scope`: Requested scopes derived from credential claims
-- `Claims`: Raw claims from the leaf credential
-- `Resource`: Target resource (e.g., expected audience)
-- `Action`: Operation being authorized (e.g., `gateway_authorize`)
-- `Context`: Additional request context (path, delegation depth, etc.)
+- `TenantID`: Tenant derived from `X-Tenant-ID` or the default tenant in single-tenant mode.
+- `Subject`: DID of the acting subject.
+- `ActingOnBehalfOf`: Delegation chain root (if applicable).
+- `Scope`: Requested scopes derived from credential claims.
+- `Claims`: Raw claims from the leaf credential.
+- `Resource`: Target resource path the caller is requesting.
+- `Action`: Operation being authorized (verb like `read`, `write`).
+- `Context`: Additional request context (path, delegation depth, etc.).
 
 ## Output Model
-- `Allow`: Boolean decision
-- `Reason`: Optional string describing the decision path
+- `Allow`: Boolean decision.
+- `Reason`: String describing the decision path (`policy_allow`, `policy_deny`, `no_matching_policy`).
+- `PolicyID`: Identifier of the policy that triggered the decision (when applicable).
 
-## Why a No-Op Default?
-The default engine returns `Allow=true` with reason `allow_all` to avoid breaking existing integrations. It ensures a clean upgrade path while letting downstream deployments plug in richer engines later.
+## Policy Schema
+- `effect`: `allow` or `deny`.
+- `actions`: List of verbs.
+- `resources`: List of resource matchers. Exact match or prefix when ending with `*` (e.g., `orders/*`).
+- `subjects`: List of subjects. Matches when:
+  - DID equals the request subject.
+  - Entry is `role:<name>` and the role exists in claims[`roles`].
+  - Entry is `any`.
+- `conditions`: Optional map supporting:
+  - `scope_contains`: String or list that must be present in `Scope`.
+  - `claim_equals`: Map of claim keys to exact values.
+- `priority`: Lower numbers evaluated first; deny overrides allow.
+- `enabled`: Disabled policies are ignored.
 
-## Roadmap
-- Attribute-based access control (ABAC)
-- Role-based access control (RBAC)
-- Permissioned delegation chains
-- Resource/action templates for gateways
-- Policy-as-code integration with versioned bundles
+## Evaluation Rules
+1. Gather policies for the tenant and filter by action, resource, subject, and conditions.
+2. Sort matching policies by `priority` then `id`.
+3. If any matching policy has `effect=deny`, the request is denied.
+4. If one or more matching `allow` policies exist and no deny matched first, the request is allowed.
+5. If no policies match, the engine denies by default.
+
+## Admin API
+Policies are managed per-tenant under `/v1/admin/policies`:
+- `POST /v1/admin/policies` – create a policy.
+- `GET /v1/admin/policies` – list policies for the tenant.
+- `GET /v1/admin/policies/{id}` – fetch a policy.
+- `PUT /v1/admin/policies/{id}` – update a policy.
+- `DELETE /v1/admin/policies/{id}` – delete a policy.
+
+All responses include `api_version`. Validation errors return standardized API errors.
+
+## Gateway Integration
+The gateway authorize handler calls the policy engine after credential verification. If policy evaluation denies (including no matching policy), the gateway returns `{allowed:false, reason:"policy_denied"}` with the `policy_id` when available. Allow decisions include the `policy_id` that permitted the request.
+
+## Examples
+```json
+{
+  "name": "orders-read",
+  "effect": "allow",
+  "actions": ["read"],
+  "resources": ["orders/*"],
+  "subjects": ["role:agent"],
+  "conditions": {"scope_contains": "orders:read"},
+  "priority": 10,
+  "enabled": true
+}
+```
+
+```json
+{
+  "name": "maintenance-freeze",
+  "effect": "deny",
+  "actions": ["write"],
+  "resources": ["*"],
+  "subjects": ["any"],
+  "priority": 1
+}
+```
+
+## Future Enhancements
+- Policy bundles and versioning.
+- Additional condition operators (time windows, IP ranges).
+- Policy simulation and dry-run endpoints.
+- Admin audit trails.

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -30,19 +30,23 @@ func main() {
 	var (
 		trustRegistry domain.TrustRegistry = domain.NewMemoryTrustRegistry()
 		db            *sql.DB
+		policyStore   policy.Store = policy.NewMemoryStore()
 	)
 
 	tenancyMode := tenant.Mode(cfg.TenancyMode)
 	var tenantStore tenant.Store = tenant.NewMemoryStore()
 
-	if cfg.UseDBTrustRegistry && cfg.DB_DSN != "" {
+	if cfg.DB_DSN != "" {
 		var err error
 		db, err = sql.Open("postgres", cfg.DB_DSN)
 		if err != nil {
 			log.Fatalf("connect to database: %v", err)
 		}
-		trustRegistry = storage.NewPGTrustRegistry(db)
+		if cfg.UseDBTrustRegistry {
+			trustRegistry = storage.NewPGTrustRegistry(db)
+		}
 		tenantStore = tenant.NewPGTenantStore(db)
+		policyStore = policy.NewPGStore(db)
 	}
 
 	if err := tenantStore.UpsertTenant(context.Background(), domain.Tenant{ID: cfg.DefaultTenantID, Name: "default", Enabled: true}); err != nil {
@@ -78,7 +82,7 @@ func main() {
 	}
 
 	readiness := func(ctx context.Context) error {
-		if cfg.UseDBTrustRegistry && db != nil {
+		if db != nil {
 			return db.PingContext(ctx)
 		}
 		return nil
@@ -101,7 +105,9 @@ func main() {
 		log.Printf("rate limiting enabled but using noop limiter; configure backend to enforce limits")
 	}
 
-	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policy.NoOpEngine{}, cfg.DefaultTenantID, signer, issuerDID, decisionCache, limiter, nil, time.Now)
+	policyEngine := policy.NewEngine(policyStore)
+	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policyEngine, cfg.DefaultTenantID, signer, issuerDID, decisionCache, limiter, nil, time.Now)
+	httpx.RegisterPolicyAdminRoutes(mux, policyStore, cfg.DefaultTenantID)
 	httpx.RegisterHealthRoutes(mux, readiness)
 
 	handler := httpx.RequestContext(httpx.TenantMiddleware(tenantResolver, httpx.LoggingMiddleware(mux)))

--- a/internal/httpx/gateway_handlers.go
+++ b/internal/httpx/gateway_handlers.go
@@ -40,6 +40,7 @@ type GatewayAuthorizeResponse struct {
 	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
 	Agent            *AgentContext          `json:"agent,omitempty"`
 	TenantID         string                 `json:"tenant_id,omitempty"`
+	PolicyID         *int64                 `json:"policy_id,omitempty"`
 	APIVersion       string                 `json:"api_version"`
 }
 
@@ -194,7 +195,9 @@ func RegisterGatewayRoutes(
 		}
 		if !policyResult.Allow {
 			gwMetrics.IncAuthzDeny(tenantID, "policy_denied")
-			WriteAPIError(w, http.StatusForbidden, "policy_denied", policyResult.Reason)
+			denyResp := GatewayAuthorizeResponse{Allowed: false, Reason: "policy_denied", TenantID: tenantID, PolicyID: policyResult.PolicyID, APIVersion: version.APIVersion}
+			logGatewayDecision(started, tenantID, denyResp, false)
+			writeDecision(w, denyResp)
 			return
 		}
 		var agentContext *AgentContext
@@ -215,7 +218,8 @@ func RegisterGatewayRoutes(
 			ActingOnBehalfOf: decision.ActingOnBehalfOf,
 			DelegationDepth:  decision.DelegationDepth,
 			Claims:           filterSafeClaims(decision.Claims),
-			Reason:           decision.Reason,
+			Reason:           policyResult.Reason,
+			PolicyID:         policyResult.PolicyID,
 			Agent:            agentContext,
 			TenantID:         tenantID,
 			APIVersion:       version.APIVersion,

--- a/internal/httpx/gateway_handlers_test.go
+++ b/internal/httpx/gateway_handlers_test.go
@@ -1,18 +1,19 @@
 package httpx
 
 import (
-	"bytes"
-	"context"
-	"crypto"
-	"crypto/ed25519"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+        "bytes"
+        "context"
+        "crypto"
+        "crypto/ed25519"
+        "encoding/json"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
 
-	"github.com/bradtumy/credential-service/internal/domain"
-	"github.com/bradtumy/credential-service/internal/version"
+        "github.com/bradtumy/credential-service/internal/domain"
+        "github.com/bradtumy/credential-service/internal/policy"
+        "github.com/bradtumy/credential-service/internal/version"
 )
 
 func TestGatewayAuthorizeAllow(t *testing.T) {
@@ -242,9 +243,9 @@ func TestGatewayAuthorizeRateLimited(t *testing.T) {
 }
 
 func TestGatewayAuthorizeCacheHitSkipsVerification(t *testing.T) {
-	cache := &recordingCache{}
-	mux := http.NewServeMux()
-	RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", cache, nil, nil, time.Now)
+        cache := &recordingCache{}
+        mux := http.NewServeMux()
+        RegisterGatewayRoutes(mux, nil, nil, nil, "tenant", nil, "", cache, nil, nil, time.Now)
 
 	// Prime cache with allowed decision.
 	cached := GatewayAuthorizeResponse{Allowed: true, Subject: "did:example:cached", TenantID: "tenant", APIVersion: version.APIVersion}
@@ -304,9 +305,103 @@ func TestGatewayAuthorizeCachesDecision(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
 	mux.ServeHTTP(rr2, req2)
 
-	if resolverCalls != resolverCallsAfterFirst {
-		t.Fatalf("expected resolver calls to remain constant on cache hit")
-	}
+        if resolverCalls != resolverCallsAfterFirst {
+                t.Fatalf("expected resolver calls to remain constant on cache hit")
+        }
+}
+
+func TestGatewayAuthorizePolicyDeny(t *testing.T) {
+        _, priv, _ := ed25519.GenerateKey(nil)
+        issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+        registry := domain.NewMemoryTrustRegistry()
+        registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
+
+        resolver := func(issuer string) (crypto.PublicKey, error) { return priv.Public(), nil }
+        token, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 5*time.Minute, map[string]any{"scope": []string{"read"}})
+
+        store := policy.NewMemoryStore()
+        _ = store.CreatePolicy(context.Background(), &policy.Policy{TenantID: "tenant", Name: "deny", Effect: policy.EffectDeny, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 1, Enabled: true})
+        engine := policy.NewEngine(store)
+
+        mux := http.NewServeMux()
+        RegisterGatewayRoutes(mux, resolver, registry, engine, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
+
+        body, _ := json.Marshal(GatewayAuthorizeRequest{Credential: token, Resource: "orders", Action: "read"})
+        rr := httptest.NewRecorder()
+        req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+        mux.ServeHTTP(rr, req)
+
+        if rr.Code != http.StatusForbidden {
+                        t.Fatalf("expected 403, got %d", rr.Code)
+        }
+        var resp GatewayAuthorizeResponse
+        _ = json.NewDecoder(rr.Body).Decode(&resp)
+        if resp.Allowed || resp.Reason != "policy_denied" {
+                        t.Fatalf("expected policy deny, got %+v", resp)
+        }
+}
+
+func TestGatewayAuthorizePolicyAllow(t *testing.T) {
+        _, priv, _ := ed25519.GenerateKey(nil)
+        issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+        registry := domain.NewMemoryTrustRegistry()
+        registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
+
+        resolver := func(issuer string) (crypto.PublicKey, error) { return priv.Public(), nil }
+        token, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 5*time.Minute, map[string]any{"scope": []string{"read"}, "roles": []string{"admin"}})
+
+        store := policy.NewMemoryStore()
+        _ = store.CreatePolicy(context.Background(), &policy.Policy{TenantID: "tenant", Name: "allow", Effect: policy.EffectAllow, Actions: []string{"read"}, Resources: []string{"orders/*"}, Subjects: []string{"role:admin"}, Priority: 1, Enabled: true})
+        engine := policy.NewEngine(store)
+
+        mux := http.NewServeMux()
+        RegisterGatewayRoutes(mux, resolver, registry, engine, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
+
+        body, _ := json.Marshal(GatewayAuthorizeRequest{Credential: token, Resource: "orders/123", Action: "read"})
+        rr := httptest.NewRecorder()
+        req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+        mux.ServeHTTP(rr, req)
+
+        if rr.Code != http.StatusOK {
+                        t.Fatalf("expected 200, got %d", rr.Code)
+        }
+        var resp GatewayAuthorizeResponse
+        _ = json.NewDecoder(rr.Body).Decode(&resp)
+        if !resp.Allowed || resp.PolicyID == nil {
+                        t.Fatalf("expected allow with policy id, got %+v", resp)
+        }
+}
+
+func TestGatewayAuthorizePolicyDefaultDeny(t *testing.T) {
+        _, priv, _ := ed25519.GenerateKey(nil)
+        issuerDID, _ := domain.DIDFromPublicKey(priv.Public())
+
+        registry := domain.NewMemoryTrustRegistry()
+        registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID)
+
+        resolver := func(issuer string) (crypto.PublicKey, error) { return priv.Public(), nil }
+        token, _ := domain.IssueBasicCredential(issuerDID, "did:example:agent", priv, 5*time.Minute, map[string]any{"scope": []string{"read"}})
+
+        engine := policy.NewEngine(policy.NewMemoryStore())
+
+        mux := http.NewServeMux()
+        RegisterGatewayRoutes(mux, resolver, registry, engine, "tenant", priv, issuerDID, nil, nil, nil, time.Now)
+
+        body, _ := json.Marshal(GatewayAuthorizeRequest{Credential: token, Resource: "orders", Action: "read"})
+        rr := httptest.NewRecorder()
+        req := httptest.NewRequest(http.MethodPost, "/v1/gateway/authorize", bytes.NewReader(body))
+        mux.ServeHTTP(rr, req)
+
+        if rr.Code != http.StatusForbidden {
+                        t.Fatalf("expected 403, got %d", rr.Code)
+        }
+        var resp GatewayAuthorizeResponse
+        _ = json.NewDecoder(rr.Body).Decode(&resp)
+        if resp.Allowed || resp.Reason != "policy_denied" {
+                        t.Fatalf("expected default policy deny, got %+v", resp)
+        }
 }
 
 type stubLimiter struct {

--- a/internal/httpx/policy_admin_handlers.go
+++ b/internal/httpx/policy_admin_handlers.go
@@ -1,0 +1,235 @@
+package httpx
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/version"
+)
+
+type PolicyRequest struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Effect      string         `json:"effect"`
+	Actions     []string       `json:"actions"`
+	Resources   []string       `json:"resources"`
+	Subjects    []string       `json:"subjects"`
+	Conditions  map[string]any `json:"conditions,omitempty"`
+	Priority    *int           `json:"priority,omitempty"`
+	Enabled     *bool          `json:"enabled,omitempty"`
+}
+
+type PolicyResponse struct {
+	Policy     policy.Policy `json:"policy"`
+	APIVersion string        `json:"api_version"`
+}
+
+type PoliciesResponse struct {
+	Policies   []policy.Policy `json:"policies"`
+	APIVersion string          `json:"api_version"`
+}
+
+// RegisterPolicyAdminRoutes wires admin policy CRUD handlers.
+func RegisterPolicyAdminRoutes(mux *http.ServeMux, store policy.Store, defaultTenantID string) {
+	mux.HandleFunc("/v1/admin/policies", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/admin/policies" {
+			WriteAPIError(w, http.StatusNotFound, "not_found", "not found")
+			return
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			handleCreatePolicy(w, r, store, defaultTenantID)
+		case http.MethodGet:
+			handleListPolicies(w, r, store, defaultTenantID)
+		default:
+			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		}
+	})
+
+	mux.HandleFunc("/v1/admin/policies/", func(w http.ResponseWriter, r *http.Request) {
+		idStr := strings.TrimPrefix(r.URL.Path, "/v1/admin/policies/")
+		if idStr == "" {
+			WriteAPIError(w, http.StatusNotFound, "not_found", "not found")
+			return
+		}
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil || id <= 0 {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "invalid policy id")
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			handleGetPolicy(w, r, store, defaultTenantID, id)
+		case http.MethodPut:
+			handleUpdatePolicy(w, r, store, defaultTenantID, id)
+		case http.MethodDelete:
+			handleDeletePolicy(w, r, store, defaultTenantID, id)
+		default:
+			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		}
+	})
+}
+
+func handleCreatePolicy(w http.ResponseWriter, r *http.Request, store policy.Store, defaultTenantID string) {
+	var req PolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteAPIError(w, http.StatusBadRequest, "bad_request", "invalid request payload")
+		return
+	}
+
+	p, err := buildPolicyFromRequest(req, TenantIDFromContext(r.Context()), defaultTenantID)
+	if err != nil {
+		WriteAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	if err := store.CreatePolicy(r.Context(), &p); err != nil {
+		WriteAPIError(w, http.StatusInternalServerError, "policy_error", err.Error())
+		return
+	}
+
+	writePolicyResponse(w, p)
+}
+
+func handleListPolicies(w http.ResponseWriter, r *http.Request, store policy.Store, defaultTenantID string) {
+	tenantID := TenantIDFromContext(r.Context())
+	if tenantID == "" {
+		tenantID = defaultTenantID
+	}
+
+	policies, err := store.ListPoliciesForTenant(r.Context(), tenantID)
+	if err != nil {
+		WriteAPIError(w, http.StatusInternalServerError, "policy_error", err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(PoliciesResponse{Policies: policies, APIVersion: version.APIVersion})
+}
+
+func handleGetPolicy(w http.ResponseWriter, r *http.Request, store policy.Store, defaultTenantID string, id int64) {
+	tenantID := TenantIDFromContext(r.Context())
+	if tenantID == "" {
+		tenantID = defaultTenantID
+	}
+
+	p, err := store.GetPolicy(r.Context(), tenantID, id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if err == policy.ErrPolicyNotFound {
+			status = http.StatusNotFound
+			WriteAPIError(w, status, "not_found", "policy not found")
+			return
+		}
+		WriteAPIError(w, status, "policy_error", err.Error())
+		return
+	}
+
+	writePolicyResponse(w, p)
+}
+
+func handleUpdatePolicy(w http.ResponseWriter, r *http.Request, store policy.Store, defaultTenantID string, id int64) {
+	var req PolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteAPIError(w, http.StatusBadRequest, "bad_request", "invalid request payload")
+		return
+	}
+
+	p, err := buildPolicyFromRequest(req, TenantIDFromContext(r.Context()), defaultTenantID)
+	if err != nil {
+		WriteAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	p.ID = id
+
+	if err := store.UpdatePolicy(r.Context(), &p); err != nil {
+		status := http.StatusInternalServerError
+		if err == policy.ErrPolicyNotFound {
+			status = http.StatusNotFound
+			WriteAPIError(w, status, "not_found", "policy not found")
+			return
+		}
+		WriteAPIError(w, status, "policy_error", err.Error())
+		return
+	}
+
+	writePolicyResponse(w, p)
+}
+
+func handleDeletePolicy(w http.ResponseWriter, r *http.Request, store policy.Store, defaultTenantID string, id int64) {
+	tenantID := TenantIDFromContext(r.Context())
+	if tenantID == "" {
+		tenantID = defaultTenantID
+	}
+
+	if err := store.DeletePolicy(r.Context(), tenantID, id); err != nil {
+		status := http.StatusInternalServerError
+		if err == policy.ErrPolicyNotFound {
+			status = http.StatusNotFound
+			WriteAPIError(w, status, "not_found", "policy not found")
+			return
+		}
+		WriteAPIError(w, status, "policy_error", err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func buildPolicyFromRequest(req PolicyRequest, tenantID, defaultTenant string) (policy.Policy, error) {
+	if tenantID == "" {
+		tenantID = defaultTenant
+	}
+	if req.Name == "" {
+		return policy.Policy{}, errField("name is required")
+	}
+	eff := strings.ToLower(req.Effect)
+	if eff != string(policy.EffectAllow) && eff != string(policy.EffectDeny) {
+		return policy.Policy{}, errField("effect must be allow or deny")
+	}
+	if len(req.Actions) == 0 || len(req.Resources) == 0 || len(req.Subjects) == 0 {
+		return policy.Policy{}, errField("actions, resources, and subjects are required")
+	}
+
+	priority := 100
+	if req.Priority != nil {
+		priority = *req.Priority
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	return policy.Policy{
+		TenantID:    tenantID,
+		Name:        req.Name,
+		Description: req.Description,
+		Effect:      policy.Effect(eff),
+		Actions:     req.Actions,
+		Resources:   req.Resources,
+		Subjects:    req.Subjects,
+		Conditions:  req.Conditions,
+		Priority:    priority,
+		Enabled:     enabled,
+	}, nil
+}
+
+func writePolicyResponse(w http.ResponseWriter, p policy.Policy) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(PolicyResponse{Policy: p, APIVersion: version.APIVersion})
+}
+
+func errField(msg string) error {
+	return &policyError{msg: msg}
+}
+
+type policyError struct {
+	msg string
+}
+
+func (e *policyError) Error() string { return e.msg }

--- a/internal/httpx/policy_admin_handlers_test.go
+++ b/internal/httpx/policy_admin_handlers_test.go
@@ -1,0 +1,97 @@
+package httpx
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/version"
+)
+
+func TestPolicyAdminCRUD(t *testing.T) {
+	store := policy.NewMemoryStore()
+	mux := http.NewServeMux()
+	RegisterPolicyAdminRoutes(mux, store, "tenant-1")
+
+	createBody := PolicyRequest{
+		Name:      "allow-read",
+		Effect:    string(policy.EffectAllow),
+		Actions:   []string{"read"},
+		Resources: []string{"orders/*"},
+		Subjects:  []string{"any"},
+	}
+	payload, _ := json.Marshal(createBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/policies", bytes.NewReader(payload))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var createResp PolicyResponse
+	_ = json.NewDecoder(rr.Body).Decode(&createResp)
+	if createResp.Policy.ID == 0 || createResp.APIVersion != version.APIVersion {
+		t.Fatalf("unexpected create response: %+v", createResp)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/admin/policies", nil)
+	listRR := httptest.NewRecorder()
+	mux.ServeHTTP(listRR, listReq)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("expected list 200, got %d", listRR.Code)
+	}
+	var listResp PoliciesResponse
+	_ = json.NewDecoder(listRR.Body).Decode(&listResp)
+	if len(listResp.Policies) != 1 {
+		t.Fatalf("expected one policy, got %d", len(listResp.Policies))
+	}
+
+	policyID := createResp.Policy.ID
+	updateBody := createBody
+	updateBody.Name = "updated"
+	updatePayload, _ := json.Marshal(updateBody)
+	updateReq := httptest.NewRequest(http.MethodPut, "/v1/admin/policies/"+strconv.FormatInt(policyID, 10), bytes.NewReader(updatePayload))
+	updateRR := httptest.NewRecorder()
+	mux.ServeHTTP(updateRR, updateReq)
+	if updateRR.Code != http.StatusOK {
+		t.Fatalf("expected update 200, got %d", updateRR.Code)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/admin/policies/"+strconv.FormatInt(policyID, 10), nil)
+	getRR := httptest.NewRecorder()
+	mux.ServeHTTP(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("expected get 200, got %d", getRR.Code)
+	}
+	var getResp PolicyResponse
+	_ = json.NewDecoder(getRR.Body).Decode(&getResp)
+	if getResp.Policy.Name != "updated" {
+		t.Fatalf("expected updated name, got %s", getResp.Policy.Name)
+	}
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/admin/policies/"+strconv.FormatInt(policyID, 10), nil)
+	delRR := httptest.NewRecorder()
+	mux.ServeHTTP(delRR, delReq)
+	if delRR.Code != http.StatusNoContent {
+		t.Fatalf("expected delete 204, got %d", delRR.Code)
+	}
+}
+
+func TestPolicyAdminValidation(t *testing.T) {
+	store := policy.NewMemoryStore()
+	mux := http.NewServeMux()
+	RegisterPolicyAdminRoutes(mux, store, "tenant-1")
+
+	badBody := PolicyRequest{}
+	payload, _ := json.Marshal(badBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/policies", bytes.NewReader(payload))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -19,6 +19,7 @@ type EvaluationInput struct {
 
 // EvaluationResult is returned by the policy engine.
 type EvaluationResult struct {
-	Allow  bool
-	Reason string
+	Allow    bool
+	Reason   string
+	PolicyID *int64
 }

--- a/internal/policy/engine_impl.go
+++ b/internal/policy/engine_impl.go
@@ -1,0 +1,258 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+)
+
+// EngineV1 evaluates policies stored in a Store.
+type EngineV1 struct {
+	store Store
+}
+
+// NewEngine constructs a V1 engine using the provided store.
+func NewEngine(store Store) *EngineV1 {
+	return &EngineV1{store: store}
+}
+
+// Evaluate resolves policies for the tenant and determines an authorization decision.
+func (e *EngineV1) Evaluate(input EvaluationInput) (EvaluationResult, error) {
+	if e == nil || e.store == nil {
+		return EvaluationResult{}, errors.New("policy store not configured")
+	}
+
+	policies, err := e.store.ListPoliciesForTenant(context.Background(), input.TenantID)
+	if err != nil {
+		return EvaluationResult{}, err
+	}
+
+	matching := filterMatchingPolicies(policies, input)
+	if len(matching) == 0 {
+		return EvaluationResult{Allow: false, Reason: "no_matching_policy"}, nil
+	}
+
+	sort.SliceStable(matching, func(i, j int) bool {
+		if matching[i].Priority == matching[j].Priority {
+			return matching[i].ID < matching[j].ID
+		}
+		return matching[i].Priority < matching[j].Priority
+	})
+
+	var allowPolicy *Policy
+	for i := range matching {
+		p := matching[i]
+		if strings.EqualFold(string(p.Effect), string(EffectDeny)) {
+			return EvaluationResult{Allow: false, Reason: "policy_deny", PolicyID: &p.ID}, nil
+		}
+		if strings.EqualFold(string(p.Effect), string(EffectAllow)) && allowPolicy == nil {
+			allowPolicy = &p
+		}
+	}
+
+	if allowPolicy != nil {
+		return EvaluationResult{Allow: true, Reason: "policy_allow", PolicyID: &allowPolicy.ID}, nil
+	}
+
+	return EvaluationResult{Allow: false, Reason: "no_allowing_policy"}, nil
+}
+
+func filterMatchingPolicies(policies []Policy, input EvaluationInput) []Policy {
+	matches := []Policy{}
+	for i := range policies {
+		p := policies[i]
+		if !p.Enabled {
+			continue
+		}
+		if !matchesAction(p, input.Action) {
+			continue
+		}
+		if !matchesResource(p, input.Resource) {
+			continue
+		}
+		if !matchesSubject(p, input.Subject, input.Claims) {
+			continue
+		}
+		if !matchesConditions(p, input) {
+			continue
+		}
+		matches = append(matches, p)
+	}
+	return matches
+}
+
+func matchesAction(p Policy, action string) bool {
+	for _, a := range p.Actions {
+		if strings.EqualFold(a, action) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesResource(p Policy, resource string) bool {
+	for _, r := range p.Resources {
+		if r == resource {
+			return true
+		}
+		if strings.HasSuffix(r, "*") {
+			prefix := strings.TrimSuffix(r, "*")
+			if strings.HasPrefix(resource, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesSubject(p Policy, subject string, claims map[string]any) bool {
+	for _, s := range p.Subjects {
+		if s == "any" {
+			return true
+		}
+		if s == subject {
+			return true
+		}
+		if strings.HasPrefix(s, "role:") {
+			role := strings.TrimPrefix(s, "role:")
+			if role == "" {
+				continue
+			}
+			if hasRole(claims, role) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasRole(claims map[string]any, role string) bool {
+	if claims == nil {
+		return false
+	}
+	rolesVal, ok := claims["roles"]
+	if !ok {
+		return false
+	}
+
+	switch v := rolesVal.(type) {
+	case []string:
+		for _, r := range v {
+			if r == role {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if str, ok := item.(string); ok && str == role {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesConditions(p Policy, input EvaluationInput) bool {
+	if len(p.Conditions) == 0 {
+		return true
+	}
+
+	for key, val := range p.Conditions {
+		switch key {
+		case "scope_contains":
+			if !scopeContains(input.Scope, val) {
+				return false
+			}
+		case "claim_equals":
+			condMap, ok := val.(map[string]any)
+			if !ok {
+				return false
+			}
+			for claimKey, claimVal := range condMap {
+				if !claimEquals(input.Claims, claimKey, claimVal) {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func scopeContains(scope []string, value any) bool {
+	switch v := value.(type) {
+	case string:
+		for _, s := range scope {
+			if s == v {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, item := range v {
+			if str, ok := item.(string); ok {
+				found := false
+				for _, s := range scope {
+					if s == str {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false
+				}
+			}
+		}
+		return true
+	case []string:
+		for _, str := range v {
+			found := false
+			for _, s := range scope {
+				if s == str {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func claimEquals(claims map[string]any, key string, expected any) bool {
+	if claims == nil {
+		return false
+	}
+	val, ok := claims[key]
+	if !ok {
+		return false
+	}
+	switch exp := expected.(type) {
+	case string:
+		str, ok := val.(string)
+		return ok && str == exp
+	case float64:
+		switch actual := val.(type) {
+		case float64:
+			return actual == exp
+		case int:
+			return float64(actual) == exp
+		}
+	case int:
+		switch actual := val.(type) {
+		case int:
+			return actual == exp
+		case float64:
+			return int(actual) == exp
+		}
+	default:
+		return val == expected
+	}
+	return false
+}

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -1,0 +1,88 @@
+package policy
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEngineAllowWithMatchingPolicy(t *testing.T) {
+	store := NewMemoryStore()
+	p := &Policy{TenantID: "t1", Name: "allow-read", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders/"}, Subjects: []string{"any"}, Priority: 5, Enabled: true}
+	_ = store.CreatePolicy(context.Background(), p)
+
+	engine := NewEngine(store)
+	res, err := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:example:alice", Resource: "orders/", Action: "read", Claims: map[string]any{"roles": []string{"user"}}, Scope: []string{"read"}})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if !res.Allow || res.PolicyID == nil || *res.PolicyID != p.ID {
+		t.Fatalf("expected allow with policy id, got %+v", res)
+	}
+}
+
+func TestEngineResourcePrefix(t *testing.T) {
+	store := NewMemoryStore()
+	p := &Policy{TenantID: "t1", Name: "prefix", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders/*"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+	_ = store.CreatePolicy(context.Background(), p)
+
+	engine := NewEngine(store)
+	res, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:x", Resource: "orders/123", Action: "read"})
+	if !res.Allow {
+		t.Fatalf("expected allow on prefix match")
+	}
+}
+
+func TestEngineRoleSubjectMatch(t *testing.T) {
+	store := NewMemoryStore()
+	p := &Policy{TenantID: "t1", Name: "role", Effect: EffectAllow, Actions: []string{"write"}, Resources: []string{"docs"}, Subjects: []string{"role:admin"}, Priority: 1, Enabled: true}
+	_ = store.CreatePolicy(context.Background(), p)
+
+	engine := NewEngine(store)
+	res, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:alice", Resource: "docs", Action: "write", Claims: map[string]any{"roles": []string{"admin"}}})
+	if !res.Allow {
+		t.Fatalf("expected allow for matching role")
+	}
+}
+
+func TestEngineConditions(t *testing.T) {
+	store := NewMemoryStore()
+	p := &Policy{TenantID: "t1", Name: "scoped", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 1, Enabled: true, Conditions: map[string]any{"scope_contains": "orders:read", "claim_equals": map[string]any{"tier": "gold"}}}
+	_ = store.CreatePolicy(context.Background(), p)
+
+	engine := NewEngine(store)
+	res, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:x", Resource: "orders", Action: "read", Scope: []string{"orders:read", "payments"}, Claims: map[string]any{"tier": "gold"}})
+	if !res.Allow {
+		t.Fatalf("expected allow when conditions satisfied")
+	}
+
+	res2, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:x", Resource: "orders", Action: "read", Scope: []string{"other"}, Claims: map[string]any{"tier": "gold"}})
+	if res2.Allow {
+		t.Fatalf("expected deny when scope missing")
+	}
+}
+
+func TestEnginePriorityDenyOverrides(t *testing.T) {
+	store := NewMemoryStore()
+	allow := &Policy{TenantID: "t1", Name: "allow", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 100, Enabled: true}
+	deny := &Policy{TenantID: "t1", Name: "deny", Effect: EffectDeny, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+	_ = store.CreatePolicy(context.Background(), allow)
+	_ = store.CreatePolicy(context.Background(), deny)
+
+	engine := NewEngine(store)
+	res, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:x", Resource: "orders", Action: "read"})
+	if res.Allow {
+		t.Fatalf("expected deny due to higher priority deny policy")
+	}
+	if res.PolicyID == nil || *res.PolicyID != deny.ID {
+		t.Fatalf("expected deny policy id")
+	}
+}
+
+func TestEngineDefaultDeny(t *testing.T) {
+	store := NewMemoryStore()
+	engine := NewEngine(store)
+	res, _ := engine.Evaluate(EvaluationInput{TenantID: "t1", Subject: "did:x", Resource: "orders", Action: "read"})
+	if res.Allow || res.Reason == "" {
+		t.Fatalf("expected default deny")
+	}
+}

--- a/internal/policy/store.go
+++ b/internal/policy/store.go
@@ -1,0 +1,18 @@
+package policy
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrPolicyNotFound indicates no policy matches the query.
+var ErrPolicyNotFound = errors.New("policy not found")
+
+// Store defines persistence behavior for policies.
+type Store interface {
+	ListPoliciesForTenant(ctx context.Context, tenantID string) ([]Policy, error)
+	CreatePolicy(ctx context.Context, p *Policy) error
+	UpdatePolicy(ctx context.Context, p *Policy) error
+	GetPolicy(ctx context.Context, tenantID string, id int64) (Policy, error)
+	DeletePolicy(ctx context.Context, tenantID string, id int64) error
+}

--- a/internal/policy/store_memory.go
+++ b/internal/policy/store_memory.go
@@ -1,0 +1,130 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// MemoryStore provides an in-memory policy repository for tests and dev.
+type MemoryStore struct {
+	mu       sync.RWMutex
+	policies map[string]map[int64]Policy
+	nextID   int64
+}
+
+// NewMemoryStore constructs a MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{policies: make(map[string]map[int64]Policy), nextID: 1}
+}
+
+// ListPoliciesForTenant returns all policies scoped to a tenant, sorted by priority then ID.
+func (m *MemoryStore) ListPoliciesForTenant(_ context.Context, tenantID string) ([]Policy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	tenantPolicies := m.policies[tenantID]
+	if tenantPolicies == nil {
+		return []Policy{}, nil
+	}
+
+	result := make([]Policy, 0, len(tenantPolicies))
+	for _, p := range tenantPolicies {
+		result = append(result, p)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Priority == result[j].Priority {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].Priority < result[j].Priority
+	})
+
+	return result, nil
+}
+
+// CreatePolicy inserts a new policy and assigns an ID.
+func (m *MemoryStore) CreatePolicy(_ context.Context, p *Policy) error {
+	if p == nil {
+		return errors.New("policy is nil")
+	}
+	if p.TenantID == "" {
+		return errors.New("tenant_id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.policies[p.TenantID] == nil {
+		m.policies[p.TenantID] = make(map[int64]Policy)
+	}
+
+	p.ID = m.nextID
+	m.nextID++
+	now := time.Now().UTC()
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	p.UpdatedAt = now
+	m.policies[p.TenantID][p.ID] = *p
+	return nil
+}
+
+// UpdatePolicy updates an existing policy.
+func (m *MemoryStore) UpdatePolicy(_ context.Context, p *Policy) error {
+	if p == nil {
+		return errors.New("policy is nil")
+	}
+	if p.TenantID == "" {
+		return errors.New("tenant_id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tenantPolicies := m.policies[p.TenantID]
+	existing, ok := tenantPolicies[p.ID]
+	if !ok {
+		return ErrPolicyNotFound
+	}
+
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = existing.CreatedAt
+	}
+	p.UpdatedAt = time.Now().UTC()
+	tenantPolicies[p.ID] = *p
+	return nil
+}
+
+// GetPolicy retrieves a policy by tenant and ID.
+func (m *MemoryStore) GetPolicy(_ context.Context, tenantID string, id int64) (Policy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if tenantPolicies := m.policies[tenantID]; tenantPolicies != nil {
+		if p, ok := tenantPolicies[id]; ok {
+			return p, nil
+		}
+	}
+	return Policy{}, ErrPolicyNotFound
+}
+
+// DeletePolicy removes a policy.
+func (m *MemoryStore) DeletePolicy(_ context.Context, tenantID string, id int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tenantPolicies := m.policies[tenantID]
+	if tenantPolicies == nil {
+		return ErrPolicyNotFound
+	}
+
+	if _, ok := tenantPolicies[id]; !ok {
+		return ErrPolicyNotFound
+	}
+
+	delete(tenantPolicies, id)
+	return nil
+}

--- a/internal/policy/store_memory_test.go
+++ b/internal/policy/store_memory_test.go
@@ -1,0 +1,63 @@
+package policy
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemoryStoreCRUD(t *testing.T) {
+	store := NewMemoryStore()
+
+	policy := &Policy{TenantID: "tenant-1", Name: "read orders", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders/*"}, Subjects: []string{"any"}, Priority: 10, Enabled: true}
+	if err := store.CreatePolicy(context.Background(), policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	got, err := store.GetPolicy(context.Background(), "tenant-1", policy.ID)
+	if err != nil {
+		t.Fatalf("get policy: %v", err)
+	}
+	if got.Name != policy.Name {
+		t.Fatalf("unexpected policy: %+v", got)
+	}
+
+	policy.Name = "read orders updated"
+	if err := store.UpdatePolicy(context.Background(), policy); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+
+	list, err := store.ListPoliciesForTenant(context.Background(), "tenant-1")
+	if err != nil {
+		t.Fatalf("list policies: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "read orders updated" {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+
+	if err := store.DeletePolicy(context.Background(), "tenant-1", policy.ID); err != nil {
+		t.Fatalf("delete policy: %v", err)
+	}
+
+	if _, err := store.GetPolicy(context.Background(), "tenant-1", policy.ID); err == nil {
+		t.Fatalf("expected error after delete")
+	}
+}
+
+func TestMemoryStoreIsolation(t *testing.T) {
+	store := NewMemoryStore()
+	p1 := &Policy{TenantID: "a", Name: "p1", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"a"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+	p2 := &Policy{TenantID: "b", Name: "p2", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"b"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+
+	_ = store.CreatePolicy(context.Background(), p1)
+	_ = store.CreatePolicy(context.Background(), p2)
+
+	listA, _ := store.ListPoliciesForTenant(context.Background(), "a")
+	listB, _ := store.ListPoliciesForTenant(context.Background(), "b")
+
+	if len(listA) != 1 || len(listB) != 1 {
+		t.Fatalf("unexpected isolation: %d %d", len(listA), len(listB))
+	}
+	if listA[0].TenantID != "a" || listB[0].TenantID != "b" {
+		t.Fatalf("tenant mismatch")
+	}
+}

--- a/internal/policy/store_pg.go
+++ b/internal/policy/store_pg.go
@@ -1,0 +1,118 @@
+package policy
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/lib/pq"
+)
+
+// PGStore persists policies in Postgres.
+type PGStore struct {
+	db *sql.DB
+}
+
+// NewPGStore constructs a Postgres policy store.
+func NewPGStore(db *sql.DB) *PGStore {
+	return &PGStore{db: db}
+}
+
+// ListPoliciesForTenant returns policies sorted by priority and id.
+func (p *PGStore) ListPoliciesForTenant(ctx context.Context, tenantID string) ([]Policy, error) {
+	const query = `SELECT id, tenant_id, name, description, effect, actions, resources, subjects, conditions, priority, enabled, created_at, updated_at FROM policies WHERE tenant_id = $1 ORDER BY priority ASC, id ASC`
+	rows, err := p.db.QueryContext(ctx, query, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	policies := []Policy{}
+	for rows.Next() {
+		var (
+			policy   Policy
+			condJSON []byte
+		)
+		if err := rows.Scan(&policy.ID, &policy.TenantID, &policy.Name, &policy.Description, &policy.Effect, pq.Array(&policy.Actions), pq.Array(&policy.Resources), pq.Array(&policy.Subjects), &condJSON, &policy.Priority, &policy.Enabled, &policy.CreatedAt, &policy.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if len(condJSON) > 0 {
+			if err := json.Unmarshal(condJSON, &policy.Conditions); err != nil {
+				return nil, err
+			}
+		}
+		policies = append(policies, policy)
+	}
+	return policies, rows.Err()
+}
+
+// CreatePolicy inserts a policy and populates ID timestamps.
+func (p *PGStore) CreatePolicy(ctx context.Context, policy *Policy) error {
+	if policy == nil {
+		return errors.New("policy is nil")
+	}
+	condJSON, err := json.Marshal(policy.Conditions)
+	if err != nil {
+		return err
+	}
+	const stmt = `INSERT INTO policies (tenant_id, name, description, effect, actions, resources, subjects, conditions, priority, enabled) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id, created_at, updated_at`
+	return p.db.QueryRowContext(ctx, stmt, policy.TenantID, policy.Name, policy.Description, policy.Effect, pq.Array(policy.Actions), pq.Array(policy.Resources), pq.Array(policy.Subjects), condJSON, policy.Priority, policy.Enabled).
+		Scan(&policy.ID, &policy.CreatedAt, &policy.UpdatedAt)
+}
+
+// UpdatePolicy updates an existing policy.
+func (p *PGStore) UpdatePolicy(ctx context.Context, policy *Policy) error {
+	if policy == nil {
+		return errors.New("policy is nil")
+	}
+	condJSON, err := json.Marshal(policy.Conditions)
+	if err != nil {
+		return err
+	}
+
+	const stmt = `UPDATE policies SET name = $1, description = $2, effect = $3, actions = $4, resources = $5, subjects = $6, conditions = $7, priority = $8, enabled = $9, updated_at = NOW() WHERE tenant_id = $10 AND id = $11 RETURNING updated_at`
+	if err := p.db.QueryRowContext(ctx, stmt, policy.Name, policy.Description, policy.Effect, pq.Array(policy.Actions), pq.Array(policy.Resources), pq.Array(policy.Subjects), condJSON, policy.Priority, policy.Enabled, policy.TenantID, policy.ID).
+		Scan(&policy.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrPolicyNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// GetPolicy fetches a single policy by tenant and id.
+func (p *PGStore) GetPolicy(ctx context.Context, tenantID string, id int64) (Policy, error) {
+	const query = `SELECT id, tenant_id, name, description, effect, actions, resources, subjects, conditions, priority, enabled, created_at, updated_at FROM policies WHERE tenant_id = $1 AND id = $2`
+	var (
+		policy   Policy
+		condJSON []byte
+	)
+	if err := p.db.QueryRowContext(ctx, query, tenantID, id).Scan(&policy.ID, &policy.TenantID, &policy.Name, &policy.Description, &policy.Effect, pq.Array(&policy.Actions), pq.Array(&policy.Resources), pq.Array(&policy.Subjects), &condJSON, &policy.Priority, &policy.Enabled, &policy.CreatedAt, &policy.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Policy{}, ErrPolicyNotFound
+		}
+		return Policy{}, err
+	}
+	if len(condJSON) > 0 {
+		if err := json.Unmarshal(condJSON, &policy.Conditions); err != nil {
+			return Policy{}, err
+		}
+	}
+	return policy, nil
+}
+
+// DeletePolicy removes a policy row.
+func (p *PGStore) DeletePolicy(ctx context.Context, tenantID string, id int64) error {
+	const stmt = `DELETE FROM policies WHERE tenant_id = $1 AND id = $2`
+	res, err := p.db.ExecContext(ctx, stmt, tenantID, id)
+	if err != nil {
+		return err
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return ErrPolicyNotFound
+	}
+	return nil
+}

--- a/internal/policy/store_pg_test.go
+++ b/internal/policy/store_pg_test.go
@@ -1,0 +1,74 @@
+package policy
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+func TestPGStoreCreateAndGet(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	store := NewPGStore(db)
+	policy := &Policy{TenantID: "tenant", Name: "test", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO policies (tenant_id, name, description, effect, actions, resources, subjects, conditions, priority, enabled) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id, created_at, updated_at")).
+		WithArgs(policy.TenantID, policy.Name, policy.Description, policy.Effect, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), policy.Priority, policy.Enabled).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(int64(1), now, now))
+
+	if err := store.CreatePolicy(context.Background(), policy); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	condJSON := []byte(`{"claim_equals":{"role":"admin"}}`)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, tenant_id, name, description, effect, actions, resources, subjects, conditions, priority, enabled, created_at, updated_at FROM policies WHERE tenant_id = $1 AND id = $2")).
+		WithArgs(policy.TenantID, policy.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "name", "description", "effect", "actions", "resources", "subjects", "conditions", "priority", "enabled", "created_at", "updated_at"}).
+			AddRow(policy.ID, policy.TenantID, policy.Name, policy.Description, policy.Effect, pq.StringArray{"read"}, pq.StringArray{"orders"}, pq.StringArray{"any"}, condJSON, policy.Priority, policy.Enabled, now, now))
+
+	fetched, err := store.GetPolicy(context.Background(), policy.TenantID, policy.ID)
+	if err != nil {
+		t.Fatalf("get policy: %v", err)
+	}
+	if fetched.ID != policy.ID || fetched.Effect != policy.Effect {
+		t.Fatalf("unexpected fetched policy: %+v", fetched)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPGStoreUpdateAndDelete(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	store := NewPGStore(db)
+	policy := &Policy{ID: 3, TenantID: "tenant", Name: "test", Effect: EffectAllow, Actions: []string{"read"}, Resources: []string{"orders"}, Subjects: []string{"any"}, Priority: 1, Enabled: true}
+
+	mock.ExpectQuery(regexp.QuoteMeta("UPDATE policies SET name = $1, description = $2, effect = $3, actions = $4, resources = $5, subjects = $6, conditions = $7, priority = $8, enabled = $9, updated_at = NOW() WHERE tenant_id = $10 AND id = $11 RETURNING updated_at")).
+		WithArgs(policy.Name, policy.Description, policy.Effect, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), policy.Priority, policy.Enabled, policy.TenantID, policy.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+
+	if err := store.UpdatePolicy(context.Background(), policy); err != nil {
+		t.Fatalf("update policy: %v", err)
+	}
+
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM policies WHERE tenant_id = $1 AND id = $2")).
+		WithArgs(policy.TenantID, policy.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.DeletePolicy(context.Background(), policy.TenantID, policy.ID); err != nil {
+		t.Fatalf("delete policy: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -1,0 +1,33 @@
+package policy
+
+import "time"
+
+// Effect defines whether a policy allows or denies.
+type Effect string
+
+const (
+	// EffectAllow permits the action when matched.
+	EffectAllow Effect = "allow"
+	// EffectDeny forbids the action when matched.
+	EffectDeny Effect = "deny"
+)
+
+// Policy represents a single authorization rule.
+type Policy struct {
+	ID          int64          `json:"id"`
+	TenantID    string         `json:"tenant_id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Effect      Effect         `json:"effect"`
+	Actions     []string       `json:"actions"`
+	Resources   []string       `json:"resources"`
+	Subjects    []string       `json:"subjects"`
+	Conditions  map[string]any `json:"conditions,omitempty"`
+	Priority    int            `json:"priority"`
+	Enabled     bool           `json:"enabled"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// Condition captures arbitrary rule constraints.
+type Condition map[string]any

--- a/migrations/0003_create_policies.sql
+++ b/migrations/0003_create_policies.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS policies (
+    id SERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    effect TEXT NOT NULL,
+    actions TEXT[] NOT NULL,
+    resources TEXT[] NOT NULL,
+    subjects TEXT[] NOT NULL,
+    conditions JSONB,
+    priority INT DEFAULT 100,
+    enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_policies_tenant ON policies(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_policies_tenant_priority ON policies(tenant_id, priority);


### PR DESCRIPTION
## Summary
- add policy domain types, migrations, stores, and engine evaluation logic
- expose tenant-scoped policy admin CRUD endpoints and wire policy checks into gateway authorize
- update verifier wiring, documentation, and comprehensive tests for policy semantics

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5b20daf8832cbda6191e43fb99d9)