### PR TITLE
Add SD-JWT issuance support with audit persistence

### DIFF
--- a/API_OVERVIEW.md
+++ b/API_OVERVIEW.md
@@ -20,9 +20,15 @@ Downstream API <- Synthetic JWT from Gateway
 
 ## Payload Examples
 - Issue: `{ "subject_did": "did:example:alice", "ttl_seconds": 600, "claims": {"aud": "orders-api"} }`
+- Issue SD-JWT: `{ "subject_did": "did:example:alice", "ttl_seconds": 600, "claims": {"email": "alice@example.com"}, "format": "sd-jwt" }` (response includes `credential` plus `disclosures`)
 - Delegate: `{ "parent_credential": "<jwt>", "delegate_did": "did:example:agent", "scope": ["read"], "ttl_seconds": 300 }`
 - Verify: `{ "credentials": ["<parent>", "<child>"], "expected_audience": "orders-api" }`
+- Verify SD-JWT: `{ "credential": "<sd-jwt>", "disclosures": ["<disc1>", "<disc2>"], "format": "sd-jwt", "expected_audience": "orders-api" }`
 - Gateway Authorize: `{ "credentials": ["<parent>", "<child>"], "expected_audience": "orders-api", "want_synthetic_jwt": true }`
 
 ## Contract Reference
 The structured schema is published at [api/openapi.yaml](api/openapi.yaml). Each successful response includes `api_version` to document the contract used.
+
+## Policies and auditing
+- Issuance requests are checked against environment-driven policy (`ISSUER_POLICY_MAX_TTL_SECONDS`, `ISSUER_POLICY_ALLOWED_SCOPES`, `ISSUER_POLICY_REQUIRED_CLAIMS`) before minting either JWT or SD-JWT credentials.
+- When `ISSUER_AUDIT_DB_DSN` is configured, credential issuance/delegation events are written to the `audit_events` Postgres table alongside structured logs for traceability.

--- a/README.md
+++ b/README.md
@@ -135,9 +135,19 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for module layout, [TENANCY.md](TENANCY.m
   const decision = await client.gatewayAuthorize({ credential: issued.credential, want_synthetic_jwt: true })
   ```
 
+## SD-JWT and issuance policies
+- **Selective Disclosure:** Request `format: "sd-jwt"` when issuing to receive a signed SD-JWT plus disclosure list. Example:
+  ```bash
+  curl -sX POST http://localhost:8080/v1/credentials/issue \
+    -d '{"subject_did":"did:example:alice","ttl_seconds":600,"claims":{"email":"alice@example.com","scope":["read"]},"format":"sd-jwt"}'
+  ```
+  Verify by POSTing the SD-JWT, `format: "sd-jwt"`, and `disclosures` back to `/v1/credentials/verify`.
+- **Issuance policy:** The issuer enforces `ISSUER_POLICY_MAX_TTL_SECONDS`, `ISSUER_POLICY_ALLOWED_SCOPES`, and `ISSUER_POLICY_REQUIRED_CLAIMS` during issuance/delegation to prevent over-broad credentials.
+- **Audit storage:** When `ISSUER_AUDIT_DB_DSN` is set the issuer persists audit rows to Postgres in addition to structured logs whenever credentials are minted.
+
 ## Roadmap / Current Status
-- **Implemented:** Issuance and delegation endpoints, DID-based verification, gateway authorization with synthetic JWT minting, seeded trust registry for local runs, tenant-scoped policy engine with Postgres or in-memory stores, health/readiness probes, optional Prometheus metrics and Redis-backed caching/rate-limiting.
-- **Upcoming (see [ROADMAP.md](ROADMAP.md)):** SD-JWT support, richer issuance policies and audit trails, deeper KMS/Vault integrations, and expanded integration/e2e testing.
+- **Implemented:** Issuance/delegation endpoints, SD-JWT issuance and verification alongside JWT VCs, policy-guarded TTL/scope/claim validation, audit trails with optional Postgres persistence, DID-based verification, gateway authorization with synthetic JWT minting, seeded trust registry for local runs, tenant-scoped policy engine with Postgres or in-memory stores, health/readiness probes, optional Prometheus metrics and Redis-backed caching/rate-limiting.
+- **Upcoming (see [ROADMAP.md](ROADMAP.md)):** Deeper KMS/Vault integrations and expanded integration/e2e testing.
 
 ## Contributing
 1. Create a feature branch: `git checkout -b feature/your-change`.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -139,11 +139,21 @@ components:
           type: integer
         claims:
           type: object
+        format:
+          type: string
+          description: Credential format, defaults to jwt-vc, set to sd-jwt for selective disclosure
       required: [subject_did, ttl_seconds]
     IssueResponse:
       type: object
       properties:
         credential:
+          type: string
+        disclosures:
+          type: array
+          description: Only returned for SD-JWT issuance
+          items:
+            type: string
+        format:
           type: string
         api_version:
           type: string
@@ -180,6 +190,13 @@ components:
           items:
             type: string
         expected_audience:
+          type: string
+        disclosures:
+          type: array
+          description: SD-JWT disclosures to be verified
+          items:
+            type: string
+        format:
           type: string
     VerifyResponse:
       type: object

--- a/cmd/issuer/main.go
+++ b/cmd/issuer/main.go
@@ -2,22 +2,36 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"log"
 	"net/http"
 	"os"
+
+	_ "github.com/lib/pq"
 
 	"github.com/bradtumy/credential-service/internal/config"
 	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/httpx"
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/storage"
 	"github.com/bradtumy/credential-service/internal/tenant"
 )
 
 func main() {
 	cfg := config.LoadIssuerConfigFromEnv()
 	logging.Init(cfg.LogLevel)
-	
+
+	var auditStore storage.AuditStore
+	if cfg.AuditDB_DSN != "" {
+		db, err := sql.Open("postgres", cfg.AuditDB_DSN)
+		if err != nil {
+			log.Fatalf("Failed to connect to audit database: %v", err)
+		}
+		auditStore = storage.NewPGAuditStore(db)
+		log.Printf("Using Postgres audit store")
+	}
+
 	// Use production keystore with automatic backend detection
 	var store keystore.KeyStore
 	if os.Getenv("USE_PRODUCTION_KEYSTORE") == "true" {
@@ -38,8 +52,8 @@ func main() {
 	resolver := tenant.Resolver{Mode: tenant.Mode(cfg.TenancyMode), DefaultTenantID: cfg.DefaultTenantID, Store: tenantStore}
 
 	mux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(mux, store, cfg)
-	httpx.RegisterBootstrapRoutes(mux, store, cfg, nil)  // Add bootstrap endpoint
+	httpx.RegisterIssuerRoutes(mux, store, cfg, auditStore)
+	httpx.RegisterBootstrapRoutes(mux, store, cfg, nil) // Add bootstrap endpoint
 	httpx.RegisterHealthRoutes(mux, nil)
 
 	// Use the new standard middleware chain with comprehensive audit logging

--- a/examples/audit-logging-demo/main.go
+++ b/examples/audit-logging-demo/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Wire routes
 	mux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(mux, store, cfg)
+	httpx.RegisterIssuerRoutes(mux, store, cfg, nil)
 	httpx.RegisterHealthRoutes(mux, nil)
 
 	// Apply comprehensive middleware chain (correlation IDs, audit, security headers)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
-	"os"
-	"strconv"
+        "os"
+        "strconv"
+
+        "github.com/bradtumy/credential-service/internal/policy"
 )
 
 // Config holds application configuration loaded from environment variables.
@@ -40,20 +42,24 @@ func getenv(key, fallback string) string {
 
 // IssuerConfig holds configuration for the issuer service.
 type IssuerConfig struct {
-	HTTPPort        string
-	DefaultTenantID string
-	TenancyMode     string
-	LogLevel        string
+        HTTPPort        string
+        DefaultTenantID string
+        TenancyMode     string
+        LogLevel        string
+        AuditDB_DSN     string
+        Policy          policy.IssuancePolicy
 }
 
 // LoadIssuerConfigFromEnv loads issuer configuration from environment variables.
 func LoadIssuerConfigFromEnv() IssuerConfig {
-	return IssuerConfig{
-		HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
-		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
-		TenancyMode:     getenv("TENANCY_MODE", "single"),
-		LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
-	}
+        return IssuerConfig{
+                HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
+                DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+                TenancyMode:     getenv("TENANCY_MODE", "single"),
+                LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
+                AuditDB_DSN:     getenv("ISSUER_AUDIT_DB_DSN", ""),
+                Policy:          policy.LoadIssuancePolicyFromEnv(),
+        }
 }
 
 // VerifierConfig holds configuration for the verifier service.

--- a/internal/domain/vc.go
+++ b/internal/domain/vc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -27,24 +28,28 @@ type VerifiableCredential struct {
 	ExpirationDate    string                 `json:"expirationDate,omitempty"`
 	CredentialSubject map[string]interface{} `json:"credentialSubject"`
 	Proof             *Proof                 `json:"proof,omitempty"`
-	
+
 	// JWT Standard Claims (when used as JWT)
-	JTI               string    `json:"jti,omitempty"`   // JWT ID (maps to ID)
-	ISS               string    `json:"iss,omitempty"`   // Issuer (maps to issuer)
-	SUB               string    `json:"sub,omitempty"`   // Subject 
-	IAT               int64     `json:"iat,omitempty"`   // Issued At (Unix timestamp)
-	EXP               int64     `json:"exp,omitempty"`   // Expires At (Unix timestamp)
-	NBF               int64     `json:"nbf,omitempty"`   // Not Before (Unix timestamp)
-	
+	JTI string `json:"jti,omitempty"` // JWT ID (maps to ID)
+	ISS string `json:"iss,omitempty"` // Issuer (maps to issuer)
+	SUB string `json:"sub,omitempty"` // Subject
+	IAT int64  `json:"iat,omitempty"` // Issued At (Unix timestamp)
+	EXP int64  `json:"exp,omitempty"` // Expires At (Unix timestamp)
+	NBF int64  `json:"nbf,omitempty"` // Not Before (Unix timestamp)
+
 	// Extension Fields for delegation and authorization
-	Scope             []string               `json:"scope,omitempty"`           // Authorized scopes
-	DelegationChain   []string               `json:"delegation_chain,omitempty"` // Chain of delegating entities
-	
+	Scope           []string `json:"scope,omitempty"`            // Authorized scopes
+	DelegationChain []string `json:"delegation_chain,omitempty"` // Chain of delegating entities
+	// Selective disclosure fields (SD-JWT)
+	Format      string   `json:"format,omitempty"`
+	SDDigests   []string `json:"_sd,omitempty"`
+	SDDigestAlg string   `json:"_sd_alg,omitempty"`
+
 	// Backward compatibility fields (deprecated but maintained for existing code)
-	Claims            map[string]interface{} `json:"claims,omitempty"`          // Legacy claims field
-	Subject           string                 `json:"subject,omitempty"`         // Legacy subject field (use SUB instead)
-	IssuedAt          time.Time              `json:"issued_at,omitempty"`       // Legacy field (use IAT instead)
-	ExpiresAt         time.Time              `json:"expires_at,omitempty"`      // Legacy field (use EXP instead)
+	Claims    map[string]interface{} `json:"claims,omitempty"`     // Legacy claims field
+	Subject   string                 `json:"subject,omitempty"`    // Legacy subject field (use SUB instead)
+	IssuedAt  time.Time              `json:"issued_at,omitempty"`  // Legacy field (use IAT instead)
+	ExpiresAt time.Time              `json:"expires_at,omitempty"` // Legacy field (use EXP instead)
 }
 
 // Proof structure for digital signature.
@@ -109,7 +114,7 @@ func BuildCredential(id, issuer string, issuanceDate, expirationDate string, sub
 	if err := ValidateCredentialSubject(subject); err != nil {
 		return VerifiableCredential{}, err
 	}
-	
+
 	// Parse and validate dates
 	if _, err := time.Parse(time.RFC3339, issuanceDate); err != nil {
 		return VerifiableCredential{}, NewFieldValidationError("issuanceDate", "must be RFC3339 format")
@@ -119,7 +124,7 @@ func BuildCredential(id, issuer string, issuanceDate, expirationDate string, sub
 			return VerifiableCredential{}, NewFieldValidationError("expirationDate", "must be RFC3339 format")
 		}
 	}
-	
+
 	return VerifiableCredential{
 		Context:           []string{"https://www.w3.org/2018/credentials/v1"},
 		Type:              []string{"VerifiableCredential"},
@@ -188,7 +193,7 @@ func IssueBasicCredential(issuerDID, subjectDID string, signer crypto.Signer, tt
 	issuedAt := time.Now().UTC()
 	expiresAt := issuedAt.Add(ttl)
 	credentialID := uuid.NewString()
-	
+
 	// Create W3C-compliant VC with proper JWT claims
 	vc := VerifiableCredential{
 		// W3C Fields
@@ -199,20 +204,20 @@ func IssueBasicCredential(issuerDID, subjectDID string, signer crypto.Signer, tt
 		IssuanceDate:      issuedAt.Format(time.RFC3339),
 		ExpirationDate:    expiresAt.Format(time.RFC3339),
 		CredentialSubject: claims,
-		
+
 		// JWT Claims
-		JTI:               credentialID,
-		ISS:               issuerDID,
-		SUB:               subjectDID,
-		IAT:               issuedAt.Unix(),
-		EXP:               expiresAt.Unix(),
-		NBF:               issuedAt.Unix(),
-		
+		JTI: credentialID,
+		ISS: issuerDID,
+		SUB: subjectDID,
+		IAT: issuedAt.Unix(),
+		EXP: expiresAt.Unix(),
+		NBF: issuedAt.Unix(),
+
 		// Backward compatibility (populate legacy fields)
-		Subject:           subjectDID,
-		Claims:            claims,
-		IssuedAt:          issuedAt,
-		ExpiresAt:         expiresAt,
+		Subject:   subjectDID,
+		Claims:    claims,
+		IssuedAt:  issuedAt,
+		ExpiresAt: expiresAt,
 	}
 
 	header := map[string]string{
@@ -239,6 +244,112 @@ func IssueBasicCredential(issuerDID, subjectDID string, signer crypto.Signer, tt
 	signatureSegment := base64.RawURLEncoding.EncodeToString(signature)
 
 	return signingInput + "." + signatureSegment, nil
+}
+
+// SDJWT represents an issued selective-disclosure credential.
+type SDJWT struct {
+	Token       string   `json:"token"`
+	Disclosures []string `json:"disclosures"`
+}
+
+// IssueSDJWTCredential issues an SD-JWT with salted digests for each claim.
+func IssueSDJWTCredential(issuerDID, subjectDID string, signer crypto.Signer, ttl time.Duration, claims map[string]interface{}) (*SDJWT, error) {
+	if claims == nil {
+		claims = map[string]interface{}{}
+	}
+
+	// Build digests
+	disclosures := make([]string, 0, len(claims))
+	digests := make([]string, 0, len(claims))
+	for key, value := range claims {
+		disclosure, digest, err := buildDisclosure(key, value)
+		if err != nil {
+			return nil, fmt.Errorf("build disclosure: %w", err)
+		}
+		disclosures = append(disclosures, disclosure)
+		digests = append(digests, digest)
+	}
+
+	sdClaims := map[string]interface{}{
+		"_sd":     digests,
+		"_sd_alg": "sha256",
+	}
+
+	token, err := IssueBasicCredentialWithFormat(issuerDID, subjectDID, signer, ttl, sdClaims, "sd-jwt")
+	if err != nil {
+		return nil, err
+	}
+
+	return &SDJWT{Token: token, Disclosures: disclosures}, nil
+}
+
+// IssueBasicCredentialWithFormat mirrors IssueBasicCredential but annotates the VC format.
+func IssueBasicCredentialWithFormat(issuerDID, subjectDID string, signer crypto.Signer, ttl time.Duration, claims map[string]interface{}, format string) (string, error) {
+	if claims == nil {
+		claims = map[string]interface{}{}
+	}
+
+	token, err := IssueBasicCredential(issuerDID, subjectDID, signer, ttl, claims)
+	if err != nil {
+		return "", err
+	}
+
+	// Rebuild payload with format annotation
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return token, nil
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return token, nil
+	}
+
+	var credential VerifiableCredential
+	if err := json.Unmarshal(payloadBytes, &credential); err != nil {
+		return token, nil
+	}
+
+	credential.Format = format
+
+	newPayload, err := encodeSegment(credential)
+	if err != nil {
+		return token, nil
+	}
+
+	signingInput := parts[0] + "." + newPayload
+	signature, err := signer.Sign(rand.Reader, []byte(signingInput), crypto.Hash(0))
+	if err != nil {
+		return "", fmt.Errorf("sign payload: %w", err)
+	}
+
+	parts[1] = newPayload
+	parts[2] = base64.RawURLEncoding.EncodeToString(signature)
+	return strings.Join(parts, "."), nil
+}
+
+func buildDisclosure(key string, value interface{}) (string, string, error) {
+	saltBytes := make([]byte, 12)
+	if _, err := rand.Read(saltBytes); err != nil {
+		return "", "", fmt.Errorf("generate salt: %w", err)
+	}
+	salt := base64.RawURLEncoding.EncodeToString(saltBytes)
+
+	disclosureArray := []interface{}{salt, key, value}
+	disclosureBytes, err := json.Marshal(disclosureArray)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal disclosure: %w", err)
+	}
+
+	disclosure := base64.RawURLEncoding.EncodeToString(disclosureBytes)
+	digest := computeDisclosureDigest(disclosureBytes)
+
+	return disclosure, digest, nil
+}
+
+func computeDisclosureDigest(disclosure []byte) string {
+	h := sha256.Sum256(disclosure)
+	return base64.RawURLEncoding.EncodeToString(h[:])
 }
 
 func encodeSegment(data interface{}) (string, error) {
@@ -294,23 +405,23 @@ func ValidateDID(did string) error {
 	if !strings.HasPrefix(did, "did:") {
 		return NewValidationError("DID must start with 'did:'")
 	}
-	
+
 	// Basic format: did:method:method-specific-id
 	parts := strings.SplitN(did, ":", 3)
 	if len(parts) < 3 {
 		return NewValidationError("DID must have format 'did:method:method-specific-id'")
 	}
-	
+
 	method := parts[1]
 	if method == "" {
 		return NewValidationError("DID method cannot be empty")
 	}
-	
+
 	methodSpecificID := parts[2]
 	if methodSpecificID == "" {
 		return NewValidationError("DID method-specific-id cannot be empty")
 	}
-	
+
 	return nil
 }
 

--- a/internal/domain/vc_verify.go
+++ b/internal/domain/vc_verify.go
@@ -23,6 +23,8 @@ var (
 	ErrDelegationScope    = errors.New("delegated scope must be subset of parent")
 	ErrDelegationTTL      = errors.New("delegated credential expires after parent")
 	ErrDelegationDepth    = errors.New("delegation depth exceeded")
+	ErrMissingDisclosure  = errors.New("disclosure missing for SD-JWT digest")
+	ErrInvalidDisclosure  = errors.New("invalid SD-JWT disclosure")
 )
 
 // VerificationResult captures the verified credential payload.
@@ -65,12 +67,13 @@ func VerifyCredentialChain(tokens []string, deps VerifierDependencies, opts Veri
 
 	credentials := make([]VerifiableCredential, 0, len(tokens))
 	for idx, token := range tokens {
+		baseToken, disclosures := parseSDJWTPayload(token)
 		expectedAudience := ""
 		if idx == len(tokens)-1 {
 			expectedAudience = opts.ExpectedAudience
 		}
 
-		credential, err := verifySingleCredential(token, deps, expectedAudience, now)
+		credential, err := verifySingleCredential(baseToken, disclosures, deps, expectedAudience, now)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +123,7 @@ func VerifyCredential(token string, deps VerifierDependencies, expectedAudience 
 	return &VerificationResult{Credential: res.Credentials[0]}, nil
 }
 
-func verifySingleCredential(token string, deps VerifierDependencies, expectedAudience string, now time.Time) (VerifiableCredential, error) {
+func verifySingleCredential(token string, disclosures []string, deps VerifierDependencies, expectedAudience string, now time.Time) (VerifiableCredential, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return VerifiableCredential{}, ErrInvalidToken
@@ -165,6 +168,12 @@ func verifySingleCredential(token string, deps VerifierDependencies, expectedAud
 		return VerifiableCredential{}, ErrIssuedInFuture
 	}
 
+	if len(credential.SDDigests) > 0 {
+		if err := applyDisclosures(&credential, disclosures); err != nil {
+			return VerifiableCredential{}, err
+		}
+	}
+
 	if expectedAudience != "" {
 		aud, _ := credential.Claims["aud"].(string)
 		if aud != expectedAudience {
@@ -173,6 +182,84 @@ func verifySingleCredential(token string, deps VerifierDependencies, expectedAud
 	}
 
 	return credential, nil
+}
+
+func parseSDJWTPayload(token string) (string, []string) {
+	parts := strings.Split(token, "~")
+	if len(parts) == 0 {
+		return token, nil
+	}
+	base := parts[0]
+	if len(parts) == 1 {
+		return base, nil
+	}
+	return base, parts[1:]
+}
+
+func applyDisclosures(vc *VerifiableCredential, disclosures []string) error {
+	if len(vc.SDDigests) == 0 {
+		return nil
+	}
+	digestSet := map[string]struct{}{}
+	for _, d := range vc.SDDigests {
+		digestSet[d] = struct{}{}
+	}
+
+	resolvedClaims := map[string]interface{}{}
+	for _, disclosure := range disclosures {
+		raw, err := base64.RawURLEncoding.DecodeString(disclosure)
+		if err != nil {
+			return ErrInvalidToken
+		}
+		var arr []interface{}
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return ErrInvalidToken
+		}
+		if len(arr) != 3 {
+			return ErrInvalidToken
+		}
+		salt, _ := arr[0].(string)
+		key, _ := arr[1].(string)
+		if salt == "" || key == "" {
+			return ErrInvalidToken
+		}
+		reconstructed, err := json.Marshal(arr)
+		if err != nil {
+			return ErrInvalidToken
+		}
+
+		digest := computeDisclosureDigest(reconstructed)
+		if _, ok := digestSet[digest]; !ok {
+			return ErrInvalidDisclosure
+		}
+		resolvedClaims[key] = arr[2]
+	}
+
+	for digest := range digestSet {
+		match := false
+		for _, disclosure := range disclosures {
+			raw, err := base64.RawURLEncoding.DecodeString(disclosure)
+			if err != nil {
+				return ErrInvalidDisclosure
+			}
+			if computeDisclosureDigest(raw) == digest {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return ErrMissingDisclosure
+		}
+	}
+
+	if vc.Claims == nil {
+		vc.Claims = map[string]interface{}{}
+	}
+	for k, v := range resolvedClaims {
+		vc.Claims[k] = v
+	}
+	vc.SDDigests = nil
+	return nil
 }
 
 func ScopeFromClaims(claims map[string]interface{}) []string {

--- a/internal/httpx/issuer_handlers.go
+++ b/internal/httpx/issuer_handlers.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/bradtumy/credential-service/internal/config"
 	"github.com/bradtumy/credential-service/internal/domain"
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/storage"
 	"github.com/bradtumy/credential-service/internal/version"
 )
 
@@ -19,12 +21,15 @@ type IssueRequest struct {
 	SubjectDID string                 `json:"subject_did"`
 	TTLSeconds int64                  `json:"ttl_seconds"`
 	Claims     map[string]interface{} `json:"claims"`
+	Format     string                 `json:"format"`
 }
 
 // IssueResponse represents the response payload after issuance.
 type IssueResponse struct {
-	Credential string `json:"credential"`
-	APIVersion string `json:"api_version"`
+	Credential  string   `json:"credential"`
+	Disclosures []string `json:"disclosures,omitempty"`
+	Format      string   `json:"format,omitempty"`
+	APIVersion  string   `json:"api_version"`
 }
 
 // DelegateRequest represents the payload for issuing delegated credentials.
@@ -36,7 +41,7 @@ type DelegateRequest struct {
 }
 
 // RegisterIssuerRoutes wires issuer HTTP routes into the provided mux.
-func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg config.IssuerConfig) {
+func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg config.IssuerConfig, auditStore storage.AuditStore) {
 	mux.HandleFunc("/v1/credentials/issue", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Only POST method is allowed")
@@ -55,14 +60,21 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			return
 		}
 
-		// Validate TTL
+		// Validate TTL with policy-aware maximum
 		ttl := time.Duration(req.TTLSeconds) * time.Second
 		if ttl <= 0 {
 			WriteValidationError(w, domain.NewFieldValidationError("ttl_seconds", "must be positive"))
 			return
 		}
-		if ttl > 24*time.Hour {
-			WriteValidationError(w, domain.NewFieldValidationError("ttl_seconds", "cannot exceed 24 hours"))
+		maxTTL := 24 * time.Hour
+		if cfg.Policy.MaxTTLSeconds > 0 {
+			policyLimit := time.Duration(cfg.Policy.MaxTTLSeconds) * time.Second
+			if policyLimit < maxTTL {
+				maxTTL = policyLimit
+			}
+		}
+		if ttl > maxTTL {
+			WriteValidationError(w, domain.NewFieldValidationError("ttl_seconds", "exceeds policy limit"))
 			return
 		}
 
@@ -72,14 +84,25 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 				WriteValidationError(w, err)
 				return
 			}
+		} else {
+			req.Claims = map[string]interface{}{}
+		}
+		if err := cfg.Policy.ValidateRequest(req.TTLSeconds, req.Claims); err != nil {
+			WriteAPIError(w, http.StatusBadRequest, "policy_violation", err.Error())
+			return
 		}
 
-                tenantID := TenantIDFromContext(r.Context())
-                if tenantID == "" {
-                        tenantID = cfg.DefaultTenantID
-                }
+		format := req.Format
+		if format == "" {
+			format = "jwt-vc"
+		}
 
-                signer, err := store.GetSigningKey(tenantID)
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = cfg.DefaultTenantID
+		}
+
+		signer, err := store.GetSigningKey(tenantID)
 		if err != nil {
 			WriteAPIError(w, http.StatusInternalServerError, "keystore_error", err.Error())
 			return
@@ -91,25 +114,57 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			return
 		}
 
-		token, err := domain.IssueBasicCredential(issuerDID, req.SubjectDID, signer, ttl, req.Claims)
-		if err != nil {
-			// Log failed credential issuance
-			logging.LogCredentialEvent(r.Context(), logging.AuditEventCredentialIssued, req.SubjectDID, issuerDID, "failure")
-			
-			var validationErr domain.ValidationError
-			if errors.As(err, &validationErr) {
-				WriteValidationError(w, err)
-			} else {
-				WriteInternalError(w, "Failed to issue credential")
+		var (
+			token       string
+			disclosures []string
+		)
+
+		if format == "sd-jwt" {
+			sdjwt, err := domain.IssueSDJWTCredential(issuerDID, req.SubjectDID, signer, ttl, req.Claims)
+			if err != nil {
+				logging.LogCredentialEvent(r.Context(), logging.AuditEventCredentialIssued, req.SubjectDID, issuerDID, "failure")
+				WriteInternalError(w, "Failed to issue SD-JWT credential")
+				return
 			}
-			return
+			token = sdjwt.Token
+			disclosures = sdjwt.Disclosures
+		} else {
+			issuedToken, err := domain.IssueBasicCredentialWithFormat(issuerDID, req.SubjectDID, signer, ttl, req.Claims, format)
+			if err != nil {
+				// Log failed credential issuance
+				logging.LogCredentialEvent(r.Context(), logging.AuditEventCredentialIssued, req.SubjectDID, issuerDID, "failure")
+
+				var validationErr domain.ValidationError
+				if errors.As(err, &validationErr) {
+					WriteValidationError(w, err)
+				} else {
+					WriteInternalError(w, "Failed to issue credential")
+				}
+				return
+			}
+			token = issuedToken
 		}
 
-		// Log successful credential issuance
-		logging.LogCredentialEvent(r.Context(), logging.AuditEventCredentialIssued, req.SubjectDID, issuerDID, "success")
+		auditEvent := logging.AuditEvent{
+			EventType:  logging.AuditEventCredentialIssued,
+			SubjectDID: req.SubjectDID,
+			IssuerDID:  issuerDID,
+			Outcome:    "success",
+			Metadata: map[string]interface{}{
+				"format":                 format,
+				"ttl_seconds":            req.TTLSeconds,
+				"claims_keys":            claimKeys(req.Claims),
+				"policy_max_ttl_seconds": cfg.Policy.MaxTTLSeconds,
+			},
+		}
+		auditEvent.Timestamp = time.Now().UTC()
+		if auditStore != nil {
+			_ = auditStore.InsertAuditEvent(r.Context(), auditEvent)
+		}
+		logging.LogAuditEvent(r.Context(), auditEvent)
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: token, APIVersion: version.APIVersion})
+		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: token, Disclosures: disclosures, Format: format, APIVersion: version.APIVersion})
 	})
 
 	mux.HandleFunc("/v1/credentials/delegate", func(w http.ResponseWriter, r *http.Request) {
@@ -149,12 +204,12 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			return
 		}
 
-                tenantID := TenantIDFromContext(r.Context())
-                if tenantID == "" {
-                        tenantID = cfg.DefaultTenantID
-                }
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = cfg.DefaultTenantID
+		}
 
-                signer, err := store.GetSigningKey(tenantID)
+		signer, err := store.GetSigningKey(tenantID)
 		if err != nil {
 			WriteAPIError(w, http.StatusInternalServerError, "keystore_error", err.Error())
 			return
@@ -208,7 +263,12 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 			claims["aud"] = aud
 		}
 
-		token, err := domain.IssueBasicCredential(issuerDID, req.DelegateDID, signer, ttl, claims)
+		if err := cfg.Policy.ValidateRequest(req.TTLSeconds, claims); err != nil {
+			WriteAPIError(w, http.StatusBadRequest, "policy_violation", err.Error())
+			return
+		}
+
+		token, err := domain.IssueBasicCredentialWithFormat(issuerDID, req.DelegateDID, signer, ttl, claims, "jwt-vc")
 		if err != nil {
 			// Log failed delegation
 			logging.LogAuditEvent(r.Context(), logging.AuditEvent{
@@ -217,8 +277,8 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 				IssuerDID:  issuerDID,
 				Outcome:    "failure",
 				Metadata: map[string]interface{}{
-					"scope":     req.Scope,
-					"parent_id": parentCred.ID,
+					"scope":       req.Scope,
+					"parent_id":   parentCred.ID,
 					"ttl_seconds": req.TTLSeconds,
 				},
 			})
@@ -227,19 +287,34 @@ func RegisterIssuerRoutes(mux *http.ServeMux, store keystore.KeyStore, cfg confi
 		}
 
 		// Log successful delegation
-		logging.LogAuditEvent(r.Context(), logging.AuditEvent{
+		event := logging.AuditEvent{
 			EventType:  logging.AuditEventDelegationCreated,
 			SubjectDID: req.DelegateDID,
 			IssuerDID:  issuerDID,
 			Outcome:    "success",
 			Metadata: map[string]interface{}{
-				"scope":     req.Scope,
-				"parent_id": parentCred.ID,
+				"scope":       req.Scope,
+				"parent_id":   parentCred.ID,
 				"ttl_seconds": req.TTLSeconds,
+				"format":      "jwt-vc",
 			},
-		})
+		}
+		event.Timestamp = time.Now().UTC()
+		if auditStore != nil {
+			_ = auditStore.InsertAuditEvent(r.Context(), event)
+		}
+		logging.LogAuditEvent(r.Context(), event)
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: token, APIVersion: version.APIVersion})
 	})
+}
+
+func claimKeys(claims map[string]interface{}) []string {
+	keys := make([]string, 0, len(claims))
+	for k := range claims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/httpx/issuer_handlers_test.go
+++ b/internal/httpx/issuer_handlers_test.go
@@ -26,7 +26,7 @@ func TestIssueHandlerSuccess(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	mux := http.NewServeMux()
-	RegisterIssuerRoutes(mux, store, cfg)
+    RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	body := IssueRequest{
 		SubjectDID: "did:jwk:subject",
@@ -70,7 +70,7 @@ func TestIssueHandlerMissingSubject(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	mux := http.NewServeMux()
-	RegisterIssuerRoutes(mux, store, cfg)
+    RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	body := IssueRequest{TTLSeconds: int64((10 * time.Minute).Seconds())}
 	payload, _ := json.Marshal(body)
@@ -101,7 +101,7 @@ func TestDelegateHandlerSuccess(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	mux := http.NewServeMux()
-	RegisterIssuerRoutes(mux, store, cfg)
+    RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	signer, err := store.GetSigningKey(cfg.DefaultTenantID)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestDelegateHandlerScopeExpansion(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	mux := http.NewServeMux()
-	RegisterIssuerRoutes(mux, store, cfg)
+    RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	signer, _ := store.GetSigningKey(cfg.DefaultTenantID)
 	issuerDID, _ := domain.DIDFromPublicKey(signer.Public())
@@ -188,7 +188,7 @@ func TestDelegateHandlerTTLExpansion(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	mux := http.NewServeMux()
-	RegisterIssuerRoutes(mux, store, cfg)
+    RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	signer, _ := store.GetSigningKey(cfg.DefaultTenantID)
 	issuerDID, _ := domain.DIDFromPublicKey(signer.Public())

--- a/internal/httpx/verifier_handlers.go
+++ b/internal/httpx/verifier_handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/bradtumy/credential-service/internal/domain"
@@ -19,6 +20,8 @@ type VerifyRequest struct {
 	Credential       string   `json:"credential"`
 	Credentials      []string `json:"credentials"`
 	ExpectedAudience string   `json:"expected_audience"`
+	Disclosures      []string `json:"disclosures"`
+	Format           string   `json:"format"`
 }
 
 // VerifyResponse represents the verifier response payload.
@@ -59,6 +62,18 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			tokens = []string{req.Credential}
 		}
 
+		if req.Format == "sd-jwt" || len(req.Disclosures) > 0 {
+			if req.Credential == "" {
+				WriteAPIError(w, http.StatusBadRequest, "invalid_request", "credential is required for sd-jwt verification")
+				return
+			}
+			combined := req.Credential
+			if len(req.Disclosures) > 0 {
+				combined = combined + "~" + strings.Join(req.Disclosures, "~")
+			}
+			tokens = []string{combined}
+		}
+
 		if len(tokens) == 0 {
 			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "credential is required")
 			return
@@ -95,10 +110,13 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			case errors.Is(err, domain.ErrExpiredCredential), errors.Is(err, domain.ErrInvalidSignature), errors.Is(err, domain.ErrUnexpectedAudience), errors.Is(err, domain.ErrIssuedInFuture):
 				reason = "invalid_credential"
 				WriteAPIError(w, http.StatusUnauthorized, reason, err.Error())
+			case errors.Is(err, domain.ErrInvalidDisclosure), errors.Is(err, domain.ErrMissingDisclosure):
+				reason = "invalid_disclosure"
+				WriteAPIError(w, http.StatusBadRequest, reason, err.Error())
 			default:
 				WriteAPIError(w, http.StatusBadRequest, reason, err.Error())
 			}
-			
+
 			// Log failed verification attempt
 			if len(tokens) > 0 {
 				logging.LogAuditEvent(r.Context(), logging.AuditEvent{
@@ -107,12 +125,12 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 					Reason:    reason,
 					Metadata: map[string]interface{}{
 						"expected_audience": req.ExpectedAudience,
-						"credential_count": len(tokens),
-						"error": err.Error(),
+						"credential_count":  len(tokens),
+						"error":             err.Error(),
 					},
 				})
 			}
-			
+
 			verifierMetrics.IncVerificationFailure(reason)
 			return
 		}
@@ -130,11 +148,12 @@ func RegisterVerifierRoutes(mux *http.ServeMux, resolver func(string) (crypto.Pu
 			IssuerDID:  leaf.Issuer,
 			Outcome:    "success",
 			Metadata: map[string]interface{}{
-				"expected_audience":     req.ExpectedAudience,
-				"credential_count":     len(tokens),
-				"delegation_depth":     chainResult.DelegationDepth,
-				"acting_on_behalf_of":  actingOnBehalfOf,
+				"expected_audience":   req.ExpectedAudience,
+				"credential_count":    len(tokens),
+				"delegation_depth":    chainResult.DelegationDepth,
+				"acting_on_behalf_of": actingOnBehalfOf,
 				"expires_at":          leaf.ExpiresAt.Format(time.RFC3339),
+				"format":              leaf.Format,
 			},
 		})
 

--- a/internal/policy/issuance_policy.go
+++ b/internal/policy/issuance_policy.go
@@ -1,0 +1,132 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// IssuancePolicy defines constraints enforced during credential issuance.
+type IssuancePolicy struct {
+	MaxTTLSeconds  int64    // maximum lifetime allowed for issued credentials
+	AllowedScopes  []string // optional allowlist of scopes
+	RequiredClaims []string // claims that must be present in the credential subject
+}
+
+// LoadIssuancePolicyFromEnv constructs a policy from environment variables.
+//   - ISSUER_POLICY_MAX_TTL_SECONDS: integer max TTL (default: 86400)
+//   - ISSUER_POLICY_ALLOWED_SCOPES: comma-separated list of scopes (optional)
+//   - ISSUER_POLICY_REQUIRED_CLAIMS: comma-separated list of claim keys that must be provided
+func LoadIssuancePolicyFromEnv() IssuancePolicy {
+	policy := IssuancePolicy{
+		MaxTTLSeconds: 86400,
+	}
+
+	if raw := os.Getenv("ISSUER_POLICY_MAX_TTL_SECONDS"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			policy.MaxTTLSeconds = v
+		}
+	}
+
+	if raw := os.Getenv("ISSUER_POLICY_ALLOWED_SCOPES"); raw != "" {
+		policy.AllowedScopes = splitAndTrim(raw)
+	}
+
+	if raw := os.Getenv("ISSUER_POLICY_REQUIRED_CLAIMS"); raw != "" {
+		policy.RequiredClaims = splitAndTrim(raw)
+	}
+
+	return policy
+}
+
+// ValidateRequest ensures the TTL and claims satisfy policy requirements.
+func (p IssuancePolicy) ValidateRequest(ttlSeconds int64, claims map[string]interface{}) error {
+	if p.MaxTTLSeconds > 0 && ttlSeconds > p.MaxTTLSeconds {
+		return fmt.Errorf("%w: ttl_seconds exceeds policy limit of %d", ErrPolicyViolation, p.MaxTTLSeconds)
+	}
+
+	if len(p.RequiredClaims) > 0 {
+		for _, key := range p.RequiredClaims {
+			if _, ok := claims[key]; !ok {
+				return fmt.Errorf("%w: missing required claim '%s'", ErrPolicyViolation, key)
+			}
+		}
+	}
+
+	if len(p.AllowedScopes) > 0 {
+		if scopeVal, ok := claims["scope"]; ok {
+			scopes := normalizeScope(scopeVal)
+			for _, requested := range scopes {
+				if !contains(p.AllowedScopes, requested) {
+					return fmt.Errorf("%w: scope '%s' not permitted by issuance policy", ErrPolicyViolation, requested)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func contains(list []string, value string) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
+func splitAndTrim(raw string) []string {
+	parts := strings.Split(raw, ",")
+	res := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			res = append(res, trimmed)
+		}
+	}
+	return res
+}
+
+func normalizeScope(scope any) []string {
+	switch v := scope.(type) {
+	case string:
+		return []string{v}
+	case []string:
+		return v
+	case []interface{}:
+		res := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				res = append(res, s)
+			}
+		}
+		return res
+	default:
+		return nil
+	}
+}
+
+// ValidateClaimsOnly checks claims without TTL; useful for SD-JWT disclosure validation.
+func (p IssuancePolicy) ValidateClaimsOnly(claims map[string]interface{}) error {
+	return p.ValidateRequest(p.MaxTTLSeconds, claims)
+}
+
+// Combine allows merging another IssuancePolicy, preferring stricter limits.
+func (p IssuancePolicy) Combine(other IssuancePolicy) IssuancePolicy {
+	combined := p
+	if other.MaxTTLSeconds > 0 && (combined.MaxTTLSeconds == 0 || other.MaxTTLSeconds < combined.MaxTTLSeconds) {
+		combined.MaxTTLSeconds = other.MaxTTLSeconds
+	}
+	if len(other.AllowedScopes) > 0 {
+		combined.AllowedScopes = other.AllowedScopes
+	}
+	if len(other.RequiredClaims) > 0 {
+		combined.RequiredClaims = other.RequiredClaims
+	}
+	return combined
+}
+
+// ErrPolicyViolation is returned when issuance constraints are not met.
+var ErrPolicyViolation = errors.New("issuance policy violation")

--- a/internal/storage/audit_store.go
+++ b/internal/storage/audit_store.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	"github.com/bradtumy/credential-service/internal/logging"
+)
+
+// AuditStore persists audit events for compliance.
+type AuditStore interface {
+	InsertAuditEvent(ctx context.Context, event logging.AuditEvent) error
+}
+
+// PGAuditStore implements AuditStore against Postgres.
+type PGAuditStore struct {
+	db *sql.DB
+}
+
+// NewPGAuditStore creates a new Postgres-backed audit store.
+func NewPGAuditStore(db *sql.DB) *PGAuditStore {
+	return &PGAuditStore{db: db}
+}
+
+// InsertAuditEvent writes an audit event row.
+func (s *PGAuditStore) InsertAuditEvent(ctx context.Context, event logging.AuditEvent) error {
+	metadataBytes, _ := json.Marshal(event.Metadata)
+	_, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO audit_events (
+                        timestamp, correlation_id, event_type, tenant_id, user_id, subject_did, issuer_did,
+                        resource, action, outcome, reason, ip_address, user_agent, metadata
+                ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+		event.Timestamp, event.CorrelationID, event.EventType, event.TenantID, event.UserID,
+		event.SubjectDID, event.IssuerDID, event.Resource, event.Action, event.Outcome,
+		event.Reason, event.IPAddress, event.UserAgent, metadataBytes,
+	)
+	return err
+}

--- a/migrations/0004_create_audit_events.sql
+++ b/migrations/0004_create_audit_events.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS audit_events (
+    id SERIAL PRIMARY KEY,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    correlation_id TEXT,
+    event_type TEXT NOT NULL,
+    tenant_id TEXT,
+    user_id TEXT,
+    subject_did TEXT,
+    issuer_did TEXT,
+    resource TEXT,
+    action TEXT,
+    outcome TEXT NOT NULL,
+    reason TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    metadata JSONB
+);

--- a/test/integration/delegation_integration_test.go
+++ b/test/integration/delegation_integration_test.go
@@ -33,7 +33,7 @@ func TestDelegationIntegration(t *testing.T) {
 
 	// Issuer server
 	issuerMux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(issuerMux, store, issuerCfg)
+	httpx.RegisterIssuerRoutes(issuerMux, store, issuerCfg, nil)
 	issuerServer := httptest.NewServer(issuerMux)
 	t.Cleanup(issuerServer.Close)
 

--- a/test/integration/did_resolution_integration_test.go
+++ b/test/integration/did_resolution_integration_test.go
@@ -19,40 +19,40 @@ import (
 	"github.com/bradtumy/credential-service/internal/metrics"
 )
 
-// TestDistributedDIDResolution tests that a verifier can verify credentials 
+// TestDistributedDIDResolution tests that a verifier can verify credentials
 // from a completely separate issuer using DID resolution without pre-configuration
 func TestDistributedDIDResolution(t *testing.T) {
-	// Simulate Organization A (Issuer) 
+	// Simulate Organization A (Issuer)
 	issuerStore := keystore.NewMemoryKeyStore()
 	issuerCfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "org-a-tenant"}
-	
+
 	issuerSigner, err := issuerStore.GetSigningKey(issuerCfg.DefaultTenantID)
 	if err != nil {
 		t.Fatalf("get issuer signing key: %v", err)
 	}
-	
+
 	issuerDID, err := domain.DIDFromPublicKey(issuerSigner.Public())
 	if err != nil {
 		t.Fatalf("derive issuer DID: %v", err)
 	}
-	
+
 	// Create issuer service
 	issuerMux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(issuerMux, issuerStore, issuerCfg)
+	httpx.RegisterIssuerRoutes(issuerMux, issuerStore, issuerCfg, nil)
 	issuerServer := httptest.NewServer(issuerMux)
 	t.Cleanup(issuerServer.Close)
-	
+
 	// Simulate Organization B (Verifier) with separate tenant and no pre-configured keys
 	verifierCfg := config.LoadVerifierConfigFromEnv()
 	verifierCfg.DefaultTenantID = "org-b-tenant" // Different organization
-	
+
 	// Create separate verifier with DID resolution (as done in our updated main.go)
 	trustRegistry := domain.NewMemoryTrustRegistry()
 	didResolver, err := domain.NewCompositeResolver(
 		domain.NewJWKResolver(), // This enables did:jwk resolution
 	)
 	require.NoError(t, err)
-	
+
 	resolver := func(issuer string) (crypto.PublicKey, error) {
 		// Check trust registry first
 		trusted, err := trustRegistry.IsTrustedIssuer(context.Background(), verifierCfg.DefaultTenantID, issuer)
@@ -62,92 +62,92 @@ func TestDistributedDIDResolution(t *testing.T) {
 		if !trusted {
 			return nil, domain.ErrUntrustedIssuer
 		}
-		
+
 		// Resolve public key from DID (this is the key part - no pre-configuration needed!)
 		return didResolver.ResolvePublicKey(context.Background(), issuer)
 	}
-	
+
 	verifierMux := http.NewServeMux()
 	httpx.RegisterVerifierRoutes(verifierMux, resolver, trustRegistry, verifierCfg.DefaultTenantID, &metrics.NoopVerifierMetrics{}, time.Now)
 	verifierServer := httptest.NewServer(verifierMux)
 	t.Cleanup(verifierServer.Close)
-	
+
 	// Step 1: Organization A issues a credential
 	issueReq := httpx.IssueRequest{
-		SubjectDID: "did:jwk:subject123", 
+		SubjectDID: "did:jwk:subject123",
 		TTLSeconds: int64((5 * time.Minute).Seconds()),
 		Claims:     map[string]interface{}{"scope": []string{"read"}, "aud": "org-b-api"},
 	}
 	issuePayload, _ := json.Marshal(issueReq)
-	
+
 	issueResp, err := http.Post(issuerServer.URL+"/v1/credentials/issue", "application/json", bytes.NewReader(issuePayload))
 	if err != nil {
 		t.Fatalf("issue credential: %v", err)
 	}
 	defer issueResp.Body.Close()
-	
+
 	if issueResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", issueResp.StatusCode)
 	}
-	
+
 	var issueResult httpx.IssueResponse
 	if err := json.NewDecoder(issueResp.Body).Decode(&issueResult); err != nil {
 		t.Fatalf("decode issue response: %v", err)
 	}
-	
+
 	// Step 2: Organization B initially doesn't trust Organization A (should fail)
 	verifyReq := httpx.VerifyRequest{
 		Credential:       issueResult.Credential,
 		ExpectedAudience: "org-b-api",
 	}
 	verifyPayload, _ := json.Marshal(verifyReq)
-	
+
 	verifyResp, err := http.Post(verifierServer.URL+"/v1/credentials/verify", "application/json", bytes.NewReader(verifyPayload))
 	if err != nil {
 		t.Fatalf("verify credential: %v", err)
 	}
 	defer verifyResp.Body.Close()
-	
+
 	// Should fail with untrusted issuer
 	if verifyResp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 (untrusted), got %d", verifyResp.StatusCode)
 	}
-	
+
 	// Step 3: Organization B decides to trust Organization A's DID
 	// This is the key distributed trust decision - no key exchange needed!
 	if err := trustRegistry.AddTrustedIssuer(context.Background(), verifierCfg.DefaultTenantID, issuerDID); err != nil {
 		t.Fatalf("add trusted issuer: %v", err)
 	}
-	
+
 	// Step 4: Now verification should succeed using DID resolution
 	verifyResp2, err := http.Post(verifierServer.URL+"/v1/credentials/verify", "application/json", bytes.NewReader(verifyPayload))
 	if err != nil {
 		t.Fatalf("verify credential after trust: %v", err)
 	}
 	defer verifyResp2.Body.Close()
-	
+
 	if verifyResp2.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200 after trust established, got %d", verifyResp2.StatusCode)
 	}
-	
+
 	var verifyResult httpx.VerifyResponse
 	if err := json.NewDecoder(verifyResp2.Body).Decode(&verifyResult); err != nil {
 		t.Fatalf("decode verify response: %v", err)
 	}
-	
+
 	// Verify the credential details
 	if verifyResult.Valid != true {
 		t.Fatalf("expected valid credential")
 	}
-	
+
 	if verifyResult.Subject != "did:jwk:subject123" {
 		t.Fatalf("unexpected subject: %s", verifyResult.Subject)
 	}
-	
+
 	if verifyResult.Issuer != issuerDID {
 		t.Fatalf("unexpected issuer: %s", verifyResult.Issuer)
 	}
-	
+
 	t.Logf("✅ Distributed verification successful!")
 	t.Logf("   Organization A (issuer): %s", issuerDID)
 	t.Logf("   Organization B (verifier): %s", verifierCfg.DefaultTenantID)

--- a/test/integration/issuer_integration_test.go
+++ b/test/integration/issuer_integration_test.go
@@ -17,7 +17,7 @@ func TestIssuerIntegration(t *testing.T) {
 	store := keystore.NewMemoryKeyStore()
 	cfg := config.LoadIssuerConfigFromEnv()
 	mux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(mux, store, cfg)
+	httpx.RegisterIssuerRoutes(mux, store, cfg, nil)
 
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)

--- a/test/multitenant/multitenant_test.go
+++ b/test/multitenant/multitenant_test.go
@@ -80,7 +80,7 @@ func TestMultiTenantEndToEnd(t *testing.T) {
 	policyEngine := &recordingEngine{allow: true}
 
 	mux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(mux, keyStore, cfg)
+	httpx.RegisterIssuerRoutes(mux, keyStore, cfg, nil)
 	httpx.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, &metrics.NoopVerifierMetrics{}, time.Now)
 	httpx.RegisterGatewayRoutes(mux, resolver, trustRegistry, policyEngine, cfg.DefaultTenantID, signingKeyA, issuerDIDs[cfg.DefaultTenantID], nil, nil, nil, time.Now)
 

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -21,7 +21,7 @@ func TestSmokeFlow(t *testing.T) {
 	issuerCfg := config.IssuerConfig{HTTPPort: "8080", DefaultTenantID: "tenant-1"}
 	issuerStore := keystore.NewMemoryKeyStore()
 	issuerMux := http.NewServeMux()
-	httpx.RegisterIssuerRoutes(issuerMux, issuerStore, issuerCfg)
+	httpx.RegisterIssuerRoutes(issuerMux, issuerStore, issuerCfg, nil)
 	issuerServer := httptest.NewServer(issuerMux)
 	t.Cleanup(issuerServer.Close)
 


### PR DESCRIPTION
## Summary
- add SD-JWT issuance and verification flows alongside existing JWT VCs with OpenAPI updates
- enforce configurable issuance policies for TTL, scopes, and required claims while persisting issuance/delegation audit rows when a Postgres DSN is provided
- document SD-JWT usage plus policy/audit behavior and add a migration for the audit_events table

## Testing
- go test ./... (interrupted locally due to long runtime)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce0120684832c98df1a53b0c03e92)