### PR TITLE
Implement Google KMS signer and enable production keystore

### DIFF
--- a/internal/crypto/kms_signer.go
+++ b/internal/crypto/kms_signer.go
@@ -12,10 +12,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	gax "github.com/googleapis/gax-go/v2"
 )
 
 // ErrKMSSigningDisabled is returned when KMS is turned off via env vars.
@@ -23,11 +25,23 @@ var ErrKMSSigningDisabled = errors.New("kms signing disabled")
 
 // KMSSigner implements Signer backed by Google Cloud KMS asymmetric keys.
 type KMSSigner struct {
-	client *kms.KeyManagementClient
+	client KMSClient
 	keyID  string
 	jwk    []byte
 	alg    string
 	kid    string
+	pubKey crypto.PublicKey
+}
+
+// KMSClient defines the subset of KMS client methods used by KMSSigner.
+type KMSClient interface {
+	GetPublicKey(context.Context, *kmspb.GetPublicKeyRequest, ...gax.CallOption) (*kmspb.PublicKey, error)
+	AsymmetricSign(context.Context, *kmspb.AsymmetricSignRequest, ...gax.CallOption) (*kmspb.AsymmetricSignResponse, error)
+}
+
+// NewKMSClient allows injection in tests.
+var NewKMSClient = func(ctx context.Context) (KMSClient, error) {
+	return kms.NewKeyManagementClient(ctx)
 }
 
 // NewKMSSignerFromEnv builds a signer if ENABLE_KMS/KMS_ENABLE is true.
@@ -40,9 +54,29 @@ func NewKMSSignerFromEnv(ctx context.Context) (*KMSSigner, error) {
 	if keyID == "" {
 		return nil, fmt.Errorf("KMS_KEY_ID is required when KMS is enabled")
 	}
-	client, err := kms.NewKeyManagementClient(ctx)
+	client, err := NewKMSClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("kms client: %w", err)
+	}
+
+	return newKMSSigner(ctx, client, keyID)
+}
+
+// NewKMSSignerWithKeyID creates a signer for the provided key resource.
+func NewKMSSignerWithKeyID(ctx context.Context, keyID string) (*KMSSigner, error) {
+	client, err := NewKMSClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("kms client: %w", err)
+	}
+	return newKMSSigner(ctx, client, keyID)
+}
+
+func newKMSSigner(ctx context.Context, client KMSClient, keyID string) (*KMSSigner, error) {
+	if client == nil {
+		return nil, fmt.Errorf("kms client is nil")
+	}
+	if keyID == "" {
+		return nil, fmt.Errorf("kms key id is required")
 	}
 
 	resp, err := client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{Name: keyID})
@@ -68,7 +102,7 @@ func NewKMSSignerFromEnv(ctx context.Context) (*KMSSigner, error) {
 		return nil, err
 	}
 
-	return &KMSSigner{client: client, keyID: keyID, jwk: jwk, alg: alg, kid: kid}, nil
+	return &KMSSigner{client: client, keyID: keyID, jwk: jwk, alg: alg, kid: kid, pubKey: pubKey}, nil
 }
 
 func jwkFromPublicKey(pub crypto.PublicKey) ([]byte, string, error) {
@@ -102,7 +136,7 @@ func jwkFromPublicKey(pub crypto.PublicKey) ([]byte, string, error) {
 func (k *KMSSigner) PublicJWK() ([]byte, error) { return append([]byte{}, k.jwk...), nil }
 
 // Sign delegates signing to Google Cloud KMS using the appropriate signing call.
-func (k *KMSSigner) Sign(payload []byte) ([]byte, error) {
+func (k *KMSSigner) Sign(_ io.Reader, payload []byte, opts crypto.SignerOpts) ([]byte, error) {
 	if k == nil || k.client == nil {
 		return nil, fmt.Errorf("kms signer not configured")
 	}
@@ -112,6 +146,10 @@ func (k *KMSSigner) Sign(payload []byte) ([]byte, error) {
 	case "EdDSA":
 		req.Data = payload
 	case "ES256":
+		if opts != nil && opts.HashFunc() == crypto.SHA256 && len(payload) == sha256.Size {
+			req.Digest = &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: payload}}
+			break
+		}
 		digest := sha256.Sum256(payload)
 		req.Digest = &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: digest[:]}}
 	default:
@@ -133,3 +171,6 @@ func (k *KMSSigner) KeyID() string { return k.kid }
 
 // ValidityWindow is empty for KMS backed keys.
 func (k *KMSSigner) ValidityWindow() (string, string) { return "", "" }
+
+// Public returns the cached public key.
+func (k *KMSSigner) Public() crypto.PublicKey { return k.pubKey }

--- a/internal/crypto/local_signer.go
+++ b/internal/crypto/local_signer.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -166,11 +167,14 @@ func finalizeKey(signer crypto.Signer) (crypto.Signer, []byte, string, error) {
 }
 
 // Sign signs payload bytes. For ECDSA keys SHA-256 is applied before signing.
-func (l *LocalSigner) Sign(payload []byte) ([]byte, error) {
+func (l *LocalSigner) Sign(_ io.Reader, payload []byte, opts crypto.SignerOpts) ([]byte, error) {
 	switch key := l.key.(type) {
 	case ed25519.PrivateKey:
 		return key.Sign(rand.Reader, payload, crypto.Hash(0))
 	case *ecdsa.PrivateKey:
+		if opts != nil && opts.HashFunc() == crypto.SHA256 && len(payload) == sha256.Size {
+			return key.Sign(rand.Reader, payload, crypto.SHA256)
+		}
 		digest := sha256.Sum256(payload)
 		return key.Sign(rand.Reader, digest[:], crypto.SHA256)
 	default:
@@ -189,6 +193,9 @@ func (l *LocalSigner) KeyID() string { return l.kid }
 
 // PublicKey returns the underlying public key.
 func (l *LocalSigner) PublicKey() crypto.PublicKey { return l.key.Public() }
+
+// Public satisfies the crypto.Signer interface.
+func (l *LocalSigner) Public() crypto.PublicKey { return l.PublicKey() }
 
 // ValidityWindow returns metadata derived from file timestamps.
 func (l *LocalSigner) ValidityWindow() (string, string) {

--- a/internal/crypto/signer.go
+++ b/internal/crypto/signer.go
@@ -1,12 +1,13 @@
 package crypto
 
+import "crypto"
+
 // Signer abstracts signing operations so implementations can back onto local keys
 // or remote KMS providers.
 type Signer interface {
+	crypto.Signer
 	// PublicJWK returns the public key in JWK form.
 	PublicJWK() ([]byte, error)
-	// Sign signs the provided payload and returns the raw signature bytes.
-	Sign(payload []byte) ([]byte, error)
 	// Algorithm returns the JOSE/JWT alg header value for this signer.
 	Algorithm() string
 }

--- a/internal/domain/vc_integration_test.go
+++ b/internal/domain/vc_integration_test.go
@@ -16,7 +16,7 @@ func TestVerifiableCredentialIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create signer: %v", err)
 	}
-	
+
 	// Wrap in adapter that implements crypto.Signer interface
 	signer := &signerAdapter{localSigner}
 
@@ -189,5 +189,5 @@ func (s *signerAdapter) Public() crypto.PublicKey {
 }
 
 func (s *signerAdapter) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return s.localSigner.Sign(digest)
+	return s.localSigner.Sign(rand, digest, opts)
 }

--- a/internal/keystore/production.go
+++ b/internal/keystore/production.go
@@ -134,10 +134,38 @@ func (p *ProductionKeyStore) getVaultKey(ctx context.Context, keyName string) (c
 }
 
 func (p *ProductionKeyStore) getGCPKMSKey(ctx context.Context, keyName string) (crypto.Signer, error) {
-	// TODO: Implement proper GCP KMS integration
-	// For now, fall back to memory store since KMSSigner doesn't implement crypto.Signer correctly
-	log.Printf("GCP KMS integration not yet complete for key %s, falling back to memory store", keyName)
-	return p.fallbackKS.GetSigningKey(keyName)
+	projectID := os.Getenv("GCP_PROJECT")
+	if projectID == "" {
+		return nil, fmt.Errorf("GCP_PROJECT is required for KMS backend")
+	}
+	location := os.Getenv("KMS_LOCATION")
+	if location == "" {
+		location = "global"
+	}
+	keyRing := os.Getenv("KMS_KEYRING")
+	if keyRing == "" {
+		return nil, fmt.Errorf("KMS_KEYRING is required for KMS backend")
+	}
+
+	baseKeyID := os.Getenv("KMS_KEY_ID")
+	if baseKeyID == "" {
+		return nil, fmt.Errorf("KMS_KEY_ID is required for KMS backend")
+	}
+
+	cryptoKey := fmt.Sprintf("%s-%s", baseKeyID, keyName)
+	version := os.Getenv("KMS_KEY_VERSION")
+	if version == "" {
+		version = "1"
+	}
+
+	keyResource := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s", projectID, location, keyRing, cryptoKey, version)
+
+	signer, err := cryptoImpl.NewKMSSignerWithKeyID(ctx, keyResource)
+	if err != nil {
+		return nil, fmt.Errorf("kms signer: %w", err)
+	}
+
+	return signer, nil
 }
 
 func (p *ProductionKeyStore) validateBackend() error {
@@ -189,7 +217,7 @@ func detectBackend() KeyBackend {
 	}
 
 	// Check for Google Cloud KMS
-	if (os.Getenv("ENABLE_KMS") == "true" || os.Getenv("KMS_ENABLE") == "true") {
+	if os.Getenv("ENABLE_KMS") == "true" || os.Getenv("KMS_ENABLE") == "true" {
 		return BackendGoogleKMS
 	}
 

--- a/internal/keystore/production_test.go
+++ b/internal/keystore/production_test.go
@@ -1,9 +1,18 @@
 package keystore
 
 import (
+	"context"
 	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"testing"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	cryptoImpl "github.com/bradtumy/credential-service/internal/crypto"
+	gax "github.com/googleapis/gax-go/v2"
 )
 
 func TestProductionKeyStore_BackendDetection(t *testing.T) {
@@ -216,6 +225,56 @@ func TestProductionKeyStore_CacheManagement(t *testing.T) {
 	}
 }
 
+func TestProductionKeyStore_KMSBackendUsesKMSSigner(t *testing.T) {
+	clearKMSEnv()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	mock := &mockKMSClient{publicKey: pub}
+	cryptoImpl.NewKMSClient = func(ctx context.Context) (cryptoImpl.KMSClient, error) {
+		return mock, nil
+	}
+	defer func() {
+		cryptoImpl.NewKMSClient = func(ctx context.Context) (cryptoImpl.KMSClient, error) {
+			return kms.NewKeyManagementClient(ctx)
+		}
+	}()
+
+	os.Setenv("ENABLE_KMS", "true")
+	os.Setenv("GCP_PROJECT", "test-project")
+	os.Setenv("KMS_KEYRING", "ring")
+	os.Setenv("KMS_KEY_ID", "key")
+	os.Setenv("KMS_LOCATION", "global")
+	defer clearKMSEnv()
+
+	store, err := NewProductionKeyStore(ProductionConfig{Backend: BackendGoogleKMS, TenantPrefix: "tenant-"})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	signer, err := store.GetSigningKey("abc")
+	if err != nil {
+		t.Fatalf("failed to get kms signing key: %v", err)
+	}
+
+	kmsSigner, ok := signer.(*cryptoImpl.KMSSigner)
+	if !ok {
+		t.Fatalf("expected KMSSigner, got %T", signer)
+	}
+
+	expectedKeyName := "projects/test-project/locations/global/keyRings/ring/cryptoKeys/key-tenant-abc/cryptoKeyVersions/1"
+	if mock.lastGetPublicName != expectedKeyName {
+		t.Fatalf("unexpected key name, got %s want %s", mock.lastGetPublicName, expectedKeyName)
+	}
+
+	if kmsSigner.Public() == nil {
+		t.Fatal("expected public key to be populated")
+	}
+}
+
 func TestProductionKeyStore_EmptyTenantID(t *testing.T) {
 	clearKMSEnv()
 
@@ -242,4 +301,26 @@ func clearKMSEnv() {
 	for _, v := range vars {
 		os.Unsetenv(v)
 	}
+}
+
+type mockKMSClient struct {
+	publicKey         ed25519.PublicKey
+	lastGetPublicName string
+}
+
+func (m *mockKMSClient) GetPublicKey(ctx context.Context, req *kmspb.GetPublicKeyRequest, _ ...gax.CallOption) (*kmspb.PublicKey, error) {
+	_ = ctx
+	m.lastGetPublicName = req.GetName()
+	der, err := x509.MarshalPKIXPublicKey(m.publicKey)
+	if err != nil {
+		return nil, err
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return &kmspb.PublicKey{Pem: string(pemBytes)}, nil
+}
+
+func (m *mockKMSClient) AsymmetricSign(ctx context.Context, req *kmspb.AsymmetricSignRequest, _ ...gax.CallOption) (*kmspb.AsymmetricSignResponse, error) {
+	_ = ctx
+	_ = req
+	return &kmspb.AsymmetricSignResponse{Signature: []byte("mock-signature")}, nil
 }


### PR DESCRIPTION
## Summary
- update KMSSigner to satisfy crypto.Signer, expose public keys, and allow injectable KMS clients
- build tenant-scoped KMS key paths for the production keystore instead of falling back to memory
- add KMS backend test coverage with mocked KMS client responses

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ce75b0aa4832cab4e1a13b0912d59)