### PR TITLE
Add DID toolkit and CLI management

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for module layout, [TENANCY.md](docs
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Module layout and component relationships.
 - [docs/LOCAL_DEV.md](docs/LOCAL_DEV.md) — Local development environment setup and tooling.
 - [docs/CLI.md](docs/CLI.md) — Building and using the `idctl` CLI helper.
+- [docs/DID.md](docs/DID.md) — DID toolkit overview and CLI usage for `did:jwk`.
 - [docs/TESTING.md](docs/TESTING.md) — Testing strategy and how to run the suites.
 - [docs/SECURITY.md](docs/SECURITY.md) — Security model, threat considerations, and hardening tips.
 - [docs/ROADMAP.md](docs/ROADMAP.md) — Planned features and upcoming work.

--- a/cmd/idctl/main.go
+++ b/cmd/idctl/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bradtumy/credential-service/internal/crypto"
+	"github.com/bradtumy/credential-service/internal/did"
 	sdk "github.com/bradtumy/credential-service/sdk/go"
 )
 
@@ -59,6 +59,12 @@ func handleDID(args []string) error {
 	switch args[0] {
 	case "create":
 		return didCreate(args[1:])
+	case "export":
+		return didExport(args[1:])
+	case "import":
+		return didImport(args[1:])
+	case "rotate":
+		return didRotate(args[1:])
 	case "-h", "--help", "help":
 		didUsage()
 		return nil
@@ -73,6 +79,8 @@ func didCreate(args []string) error {
 	fs := flag.NewFlagSet("did create", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	algorithm := fs.String("alg", "EdDSA", "Key algorithm (EdDSA or ES256)")
+	storePath := fs.String("store", did.DefaultStorePath(), "Path to DID store JSON file")
+	label := fs.String("label", "", "Optional label for this DID (defaults to DID value)")
 
 	if err := fs.Parse(args); err != nil {
 		fs.SetOutput(os.Stderr)
@@ -80,26 +88,135 @@ func didCreate(args []string) error {
 		return err
 	}
 
-	kp, err := crypto.GenerateDIDJWK(*algorithm)
+	doc, err := did.NewDIDJWKWithAlg(*algorithm)
 	if err != nil {
 		return fmt.Errorf("generate did:jwk: %w", err)
 	}
 
-	var publicJWK map[string]interface{}
-	if err := json.Unmarshal(kp.PublicJWK, &publicJWK); err != nil {
-		return fmt.Errorf("decode public jwk: %w", err)
+	store := did.NewFileStore(*storePath)
+	if err := store.Load(); err != nil {
+		return fmt.Errorf("load DID store: %w", err)
 	}
 
-	output := map[string]interface{}{
-		"did":             kp.DID,
-		"algorithm":       kp.Algorithm,
-		"public_jwk":      publicJWK,
-		"private_key_pem": strings.TrimSpace(string(kp.PrivateKeyPEM)),
+	if err := store.Save(*label, doc); err != nil {
+		return fmt.Errorf("save DID: %w", err)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(output)
+	return printDID(doc)
+}
+
+func didExport(args []string) error {
+	fs := flag.NewFlagSet("did export", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	label := fs.String("label", "", "Label of the DID to export")
+	output := fs.String("output", "", "File to write the DID document (default: stdout)")
+	storePath := fs.String("store", did.DefaultStorePath(), "Path to DID store JSON file")
+
+	if err := fs.Parse(args); err != nil {
+		fs.SetOutput(os.Stderr)
+		fs.Usage()
+		return err
+	}
+
+	if *label == "" {
+		return errors.New("--label is required")
+	}
+
+	store, err := loadStore(*storePath)
+	if err != nil {
+		return err
+	}
+
+	doc, ok := store.Get(*label)
+	if !ok {
+		return fmt.Errorf("did not find entry for label %s", *label)
+	}
+
+	data, err := did.ExportDID(doc)
+	if err != nil {
+		return fmt.Errorf("export DID: %w", err)
+	}
+
+	if *output == "" {
+		os.Stdout.Write(data)
+		if len(data) == 0 || data[len(data)-1] != '\n' {
+			fmt.Fprintln(os.Stdout)
+		}
+		return nil
+	}
+
+	return os.WriteFile(*output, data, 0o600)
+}
+
+func didImport(args []string) error {
+	fs := flag.NewFlagSet("did import", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	file := fs.String("file", "", "Path to a DID document JSON file")
+	label := fs.String("label", "", "Label to store the DID under (default: DID value)")
+	storePath := fs.String("store", did.DefaultStorePath(), "Path to DID store JSON file")
+
+	if err := fs.Parse(args); err != nil {
+		fs.SetOutput(os.Stderr)
+		fs.Usage()
+		return err
+	}
+
+	if *file == "" {
+		return errors.New("--file is required")
+	}
+
+	data, err := os.ReadFile(*file)
+	if err != nil {
+		return fmt.Errorf("read DID file: %w", err)
+	}
+
+	doc, err := did.ImportDID(data)
+	if err != nil {
+		return fmt.Errorf("import DID: %w", err)
+	}
+
+	store, err := loadStore(*storePath)
+	if err != nil {
+		return err
+	}
+
+	if err := store.Save(*label, doc); err != nil {
+		return fmt.Errorf("save DID: %w", err)
+	}
+
+	return printDID(doc)
+}
+
+func didRotate(args []string) error {
+	fs := flag.NewFlagSet("did rotate", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	label := fs.String("label", "", "Label of the DID to rotate")
+	storePath := fs.String("store", did.DefaultStorePath(), "Path to DID store JSON file")
+
+	if err := fs.Parse(args); err != nil {
+		fs.SetOutput(os.Stderr)
+		fs.Usage()
+		return err
+	}
+
+	if *label == "" {
+		return errors.New("--label is required")
+	}
+
+	store, err := loadStore(*storePath)
+	if err != nil {
+		return err
+	}
+
+	doc, err := store.Rotate(*label)
+	if err != nil {
+		return fmt.Errorf("rotate DID: %w", err)
+	}
+
+	return printDID(doc)
 }
 
 func handleVC(args []string) error {
@@ -209,17 +326,23 @@ Usage:
   idctl vc <command> [options]
 
 Commands:
-  did create           Generate a did:jwk identifier
+  did create           Generate a did:jwk identifier and save to the local store
+  did export           Export a stored DID document
+  did import           Import a DID document JSON file
+  did rotate           Rotate a DID's keys and update the store
   vc issue             Issue a verifiable credential
   vc verify            Verify a credential
 `)
 }
 
 func didUsage() {
-	fmt.Fprintf(os.Stderr, `Usage: idctl did create [options]
+	fmt.Fprintf(os.Stderr, `Usage: idctl did <command> [options]
 
-Options:
-  --alg string   Key algorithm (EdDSA or ES256). Default: EdDSA
+Commands:
+  create   Generate a did:jwk identifier (options: --alg, --store, --label)
+  export   Export a DID document (options: --label, --output, --store)
+  import   Import a DID document (options: --file, --label, --store)
+  rotate   Rotate a DID's key (options: --label, --store)
 `)
 }
 
@@ -237,6 +360,33 @@ func envDefault(key, fallback string) string {
 		return val
 	}
 	return fallback
+}
+
+func loadStore(path string) (*did.FileStore, error) {
+	store := did.NewFileStore(path)
+	if err := store.Load(); err != nil {
+		return nil, fmt.Errorf("load DID store: %w", err)
+	}
+	return store, nil
+}
+
+func printDID(doc did.DIDDocument) error {
+	key, err := doc.CurrentKey()
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]interface{}{
+		"did":             doc.DID,
+		"algorithm":       key.Algorithm,
+		"current_key_id":  doc.CurrentKeyID,
+		"public_jwk":      key.PublicJWK,
+		"private_key_pem": strings.TrimSpace(key.PrivateKeyPEM),
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
 }
 
 func parseScope(scope string) []string {

--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 
-	"github.com/bradtumy/credential-service/internal/crypto"
+	"github.com/bradtumy/credential-service/internal/did"
 )
 
 func main() {
@@ -28,22 +29,34 @@ func main() {
 	}
 
 	// Generate the DID and key pair
-	keypair, err := crypto.GenerateDIDJWK(*algorithm)
+	doc, err := did.NewDIDJWKWithAlg(*algorithm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error generating DID: %v\n", err)
 		os.Exit(1)
 	}
 
+	key, err := doc.CurrentKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting current key: %v\n", err)
+		os.Exit(1)
+	}
+
+	publicJWK, err := json.Marshal(key.PublicJWK)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding public JWK: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Always output the DID
-	fmt.Printf("DID: %s\n", keypair.DID)
-	fmt.Printf("Algorithm: %s\n", keypair.Algorithm)
-	fmt.Printf("Public JWK: %s\n", string(keypair.PublicJWK))
+	fmt.Printf("DID: %s\n", doc.DID)
+	fmt.Printf("Algorithm: %s\n", key.Algorithm)
+	fmt.Printf("Public JWK: %s\n", string(publicJWK))
 
 	// Output private key if requested
 	if !*didOnly {
 		if *output != "" {
 			// Save private key to file
-			err := os.WriteFile(*output, keypair.PrivateKeyPEM, 0600)
+			err := os.WriteFile(*output, []byte(key.PrivateKeyPEM), 0600)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error writing private key to file: %v\n", err)
 				os.Exit(1)
@@ -52,13 +65,13 @@ func main() {
 			fmt.Println("\nKeep this file secure! It can be used to sign credentials as this DID.")
 		} else {
 			// Output private key to stdout
-			fmt.Printf("\nPrivate Key (PEM format):\n%s\n", string(keypair.PrivateKeyPEM))
+			fmt.Printf("\nPrivate Key (PEM format):\n%s\n", key.PrivateKeyPEM)
 			fmt.Println("⚠️  Keep this private key secure! It can be used to sign credentials as this DID.")
 		}
 	}
 
 	fmt.Println("\nYou can now use this DID in credential issuance requests:")
-	fmt.Printf("  subject_did: \"%s\"\n", keypair.DID)
+	fmt.Printf("  subject_did: \"%s\"\n", doc.DID)
 }
 
 func printUsage() {

--- a/docs/DID.md
+++ b/docs/DID.md
@@ -1,0 +1,23 @@
+# DID Toolkit
+
+The project ships with a lightweight DID toolkit focused on the `did:jwk` method. A `did:jwk` identifier encodes the public key material directly in the DID string, which makes it easy to bootstrap signing and verification flows without an external DID registry.
+
+## Generating and managing DIDs
+
+The `idctl` CLI can create, export, import, and rotate DIDs using a local JSON store (default: `~/.credential-service/dids.json`). Each entry keeps a small rotation history so you can continue to verify credentials signed with older keys.
+
+```bash
+# Create a new DID and persist it (defaults to EdDSA)
+idctl did create --label issuer
+
+# Export a DID document to a file
+idctl did export --label issuer --output issuer.did.json
+
+# Import an existing DID document
+idctl did import --file issuer.did.json --label issuer
+
+# Rotate keys for a stored DID
+idctl did rotate --label issuer
+```
+
+The stored documents include the DID string, the active key, and prior keys for basic history tracking. If you need to change the storage location, set `DID_STORE_PATH` for the services or pass `--store` to the CLI commands.

--- a/internal/did/doc.go
+++ b/internal/did/doc.go
@@ -1,0 +1,168 @@
+package did
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	cryptokit "github.com/bradtumy/credential-service/internal/crypto"
+)
+
+const (
+	methodJWK    = "did:jwk"
+	maxKeyRecord = 5
+)
+
+// DIDDocument captures a DID and its key rotation history.
+type DIDDocument struct {
+	DID          string     `json:"did"`
+	Method       string     `json:"method"`
+	Keys         []KeyEntry `json:"keys"`
+	CurrentKeyID string     `json:"current_key_id"`
+}
+
+// KeyEntry tracks an individual key version for a DID.
+type KeyEntry struct {
+	ID            string                 `json:"id"`
+	DID           string                 `json:"did"`
+	Algorithm     string                 `json:"algorithm"`
+	PublicJWK     map[string]interface{} `json:"public_jwk"`
+	PrivateKeyPEM string                 `json:"private_key_pem,omitempty"`
+	CreatedAt     time.Time              `json:"created_at"`
+}
+
+// NewDIDJWK creates a new did:jwk DIDDocument using the EdDSA algorithm.
+func NewDIDJWK() (DIDDocument, error) {
+	return NewDIDJWKWithAlg("EdDSA")
+}
+
+// NewDIDJWKWithAlg creates a new did:jwk DIDDocument using the provided algorithm.
+func NewDIDJWKWithAlg(algorithm string) (DIDDocument, error) {
+	keyEntry, err := generateKey(algorithm)
+	if err != nil {
+		return DIDDocument{}, err
+	}
+
+	doc := DIDDocument{
+		DID:          keyEntry.DID,
+		Method:       methodJWK,
+		Keys:         []KeyEntry{keyEntry},
+		CurrentKeyID: keyEntry.ID,
+	}
+
+	return doc, nil
+}
+
+// ExportDID serializes a DIDDocument to JSON.
+func ExportDID(doc DIDDocument) ([]byte, error) {
+	return jsonMarshal(doc)
+}
+
+// ImportDID deserializes a DIDDocument from JSON.
+func ImportDID(data []byte) (DIDDocument, error) {
+	var doc DIDDocument
+	if err := jsonUnmarshal(data, &doc); err != nil {
+		return DIDDocument{}, err
+	}
+
+	if doc.CurrentKeyID == "" || len(doc.Keys) == 0 {
+		return DIDDocument{}, errors.New("invalid DID document: missing keys")
+	}
+
+	return doc, nil
+}
+
+// RotateKeys issues a new key for the DID and keeps a bounded history.
+func RotateKeys(doc DIDDocument) (DIDDocument, error) {
+	current, err := doc.CurrentKey()
+	if err != nil {
+		return DIDDocument{}, err
+	}
+
+	next, err := generateKey(current.Algorithm)
+	if err != nil {
+		return DIDDocument{}, err
+	}
+
+	doc.DID = next.DID
+	doc.CurrentKeyID = next.ID
+	doc.Keys = append(doc.Keys, next)
+
+	if len(doc.Keys) > maxKeyRecord {
+		doc.Keys = doc.Keys[len(doc.Keys)-maxKeyRecord:]
+	}
+
+	return doc, nil
+}
+
+// CurrentKey returns the active key entry for the DIDDocument.
+func (d DIDDocument) CurrentKey() (KeyEntry, error) {
+	for _, k := range d.Keys {
+		if k.ID == d.CurrentKeyID {
+			return k, nil
+		}
+	}
+	return KeyEntry{}, fmt.Errorf("current key %s not found", d.CurrentKeyID)
+}
+
+// CurrentSigner returns the crypto.Signer for the active key.
+func (d DIDDocument) CurrentSigner() (crypto.Signer, error) {
+	current, err := d.CurrentKey()
+	if err != nil {
+		return nil, err
+	}
+
+	if current.PrivateKeyPEM == "" {
+		return nil, errors.New("current key is missing private key material")
+	}
+
+	block, _ := pem.Decode([]byte(current.PrivateKeyPEM))
+	if block == nil {
+		return nil, errors.New("failed to decode PEM block")
+	}
+
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+
+	signer, ok := parsed.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("parsed private key does not implement crypto.Signer")
+	}
+
+	return signer, nil
+}
+
+func generateKey(algorithm string) (KeyEntry, error) {
+	kp, err := cryptokit.GenerateDIDJWK(algorithm)
+	if err != nil {
+		return KeyEntry{}, err
+	}
+
+	var public map[string]interface{}
+	if err := jsonUnmarshal(kp.PublicJWK, &public); err != nil {
+		return KeyEntry{}, fmt.Errorf("decode public jwk: %w", err)
+	}
+
+	return KeyEntry{
+		ID:            uuid.NewString(),
+		DID:           kp.DID,
+		Algorithm:     kp.Algorithm,
+		PublicJWK:     public,
+		PrivateKeyPEM: string(kp.PrivateKeyPEM),
+		CreatedAt:     time.Now().UTC(),
+	}, nil
+}
+
+// jsonMarshal and jsonUnmarshal are small wrappers to aid testing/mocking.
+var (
+	jsonMarshal   = func(v interface{}) ([]byte, error) { return json.MarshalIndent(v, "", "  ") }
+	jsonUnmarshal = json.Unmarshal
+)

--- a/internal/did/doc_test.go
+++ b/internal/did/doc_test.go
@@ -1,0 +1,80 @@
+package did
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewDIDJWK(t *testing.T) {
+	doc, err := NewDIDJWK()
+	if err != nil {
+		t.Fatalf("NewDIDJWK returned error: %v", err)
+	}
+
+	if !strings.HasPrefix(doc.DID, "did:jwk:") {
+		t.Fatalf("expected did:jwk prefix, got %s", doc.DID)
+	}
+
+	if doc.CurrentKeyID == "" {
+		t.Fatalf("CurrentKeyID should be set")
+	}
+
+	if len(doc.Keys) != 1 {
+		t.Fatalf("expected a single key entry, got %d", len(doc.Keys))
+	}
+}
+
+func TestExportImportRoundTrip(t *testing.T) {
+	doc, err := NewDIDJWK()
+	if err != nil {
+		t.Fatalf("NewDIDJWK returned error: %v", err)
+	}
+
+	exported, err := ExportDID(doc)
+	if err != nil {
+		t.Fatalf("ExportDID returned error: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(exported, &raw); err != nil {
+		t.Fatalf("exported JSON invalid: %v", err)
+	}
+
+	imported, err := ImportDID(exported)
+	if err != nil {
+		t.Fatalf("ImportDID returned error: %v", err)
+	}
+
+	if imported.DID != doc.DID {
+		t.Fatalf("imported DID mismatch: %s vs %s", imported.DID, doc.DID)
+	}
+
+	if imported.CurrentKeyID != doc.CurrentKeyID {
+		t.Fatalf("current key mismatch after import")
+	}
+}
+
+func TestRotateKeys(t *testing.T) {
+	doc, err := NewDIDJWK()
+	if err != nil {
+		t.Fatalf("NewDIDJWK returned error: %v", err)
+	}
+
+	rotated, err := RotateKeys(doc)
+	if err != nil {
+		t.Fatalf("RotateKeys returned error: %v", err)
+	}
+
+	if rotated.DID == doc.DID {
+		t.Fatalf("expected rotated DID to change")
+	}
+
+	if len(rotated.Keys) != 2 {
+		t.Fatalf("expected two key entries after rotation, got %d", len(rotated.Keys))
+	}
+
+	if rotated.CurrentKeyID == doc.CurrentKeyID {
+		t.Fatalf("current key id should update after rotation")
+	}
+}

--- a/internal/did/store.go
+++ b/internal/did/store.go
@@ -1,0 +1,129 @@
+package did
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// FileStore provides a simple JSON-backed DID store for local development.
+type FileStore struct {
+	path string
+
+	mu   sync.Mutex
+	docs map[string]DIDDocument
+}
+
+// NewFileStore builds a FileStore for the given path.
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path: path, docs: make(map[string]DIDDocument)}
+}
+
+// Path returns the underlying store location.
+func (s *FileStore) Path() string {
+	return s.path
+}
+
+// DefaultStorePath returns the default path for persisted DIDs.
+func DefaultStorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "dids.json"
+	}
+	return filepath.Join(home, ".credential-service", "dids.json")
+}
+
+// Load initializes the in-memory cache from disk.
+func (s *FileStore) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("ensure store directory: %w", err)
+	}
+
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		s.docs = make(map[string]DIDDocument)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read store: %w", err)
+	}
+
+	var docs map[string]DIDDocument
+	if err := jsonUnmarshal(data, &docs); err != nil {
+		return fmt.Errorf("decode store: %w", err)
+	}
+
+	s.docs = docs
+	return nil
+}
+
+// Save writes the provided DIDDocument under the supplied label.
+func (s *FileStore) Save(label string, doc DIDDocument) error {
+	if label == "" {
+		label = doc.DID
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.docs[label] = doc
+	return s.persist()
+}
+
+// Get retrieves a DIDDocument by label.
+func (s *FileStore) Get(label string) (DIDDocument, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	doc, ok := s.docs[label]
+	return doc, ok
+}
+
+// List returns a copy of the in-memory DID documents keyed by label.
+func (s *FileStore) List() map[string]DIDDocument {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make(map[string]DIDDocument, len(s.docs))
+	for k, v := range s.docs {
+		out[k] = v
+	}
+	return out
+}
+
+// Rotate performs a key rotation for the label and persists the change.
+func (s *FileStore) Rotate(label string) (DIDDocument, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	doc, ok := s.docs[label]
+	if !ok {
+		return DIDDocument{}, fmt.Errorf("did not find entry for label %s", label)
+	}
+
+	rotated, err := RotateKeys(doc)
+	if err != nil {
+		return DIDDocument{}, err
+	}
+
+	s.docs[label] = rotated
+	if err := s.persist(); err != nil {
+		return DIDDocument{}, err
+	}
+
+	return rotated, nil
+}
+
+func (s *FileStore) persist() error {
+	data, err := jsonMarshal(s.docs)
+	if err != nil {
+		return fmt.Errorf("encode store: %w", err)
+	}
+
+	return os.WriteFile(s.path, data, 0o600)
+}

--- a/internal/did/store_test.go
+++ b/internal/did/store_test.go
@@ -1,0 +1,52 @@
+package did
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := tmp + "/dids.json"
+
+	store := NewFileStore(path)
+	if err := store.Load(); err != nil {
+		t.Fatalf("load empty store: %v", err)
+	}
+
+	doc, err := NewDIDJWK()
+	if err != nil {
+		t.Fatalf("NewDIDJWK: %v", err)
+	}
+
+	if err := store.Save("issuer", doc); err != nil {
+		t.Fatalf("save doc: %v", err)
+	}
+
+	loaded := NewFileStore(path)
+	if err := loaded.Load(); err != nil {
+		t.Fatalf("reload store: %v", err)
+	}
+
+	got, ok := loaded.Get("issuer")
+	if !ok {
+		t.Fatalf("expected issuer label to exist")
+	}
+
+	if got.DID != doc.DID {
+		t.Fatalf("expected DID %s, got %s", doc.DID, got.DID)
+	}
+
+	rotated, err := loaded.Rotate("issuer")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+
+	if rotated.DID == doc.DID {
+		t.Fatalf("rotation did not update DID")
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected store file to exist: %v", err)
+	}
+}

--- a/internal/httpserver/keygen_handlers.go
+++ b/internal/httpserver/keygen_handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/bradtumy/credential-service/internal/crypto"
+	"github.com/bradtumy/credential-service/internal/did"
 	"github.com/bradtumy/credential-service/internal/logging"
 )
 
@@ -53,29 +53,43 @@ func HandleKeygeneration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate DID and key pair
-	keypair, err := crypto.GenerateDIDJWK(req.Algorithm)
+	doc, err := did.NewDIDJWKWithAlg(req.Algorithm)
 	if err != nil {
 		logging.Logger.Error("Failed to generate DID", "error", err, "algorithm", req.Algorithm)
 		http.Error(w, `{"error":"failed to generate DID"}`, http.StatusInternalServerError)
 		return
 	}
 
+	key, err := doc.CurrentKey()
+	if err != nil {
+		logging.Logger.Error("Failed to extract current key", "error", err)
+		http.Error(w, `{"error":"failed to generate DID"}`, http.StatusInternalServerError)
+		return
+	}
+
+	publicJWK, err := json.Marshal(key.PublicJWK)
+	if err != nil {
+		logging.Logger.Error("Failed to marshal public JWK", "error", err)
+		http.Error(w, `{"error":"failed to generate DID"}`, http.StatusInternalServerError)
+		return
+	}
+
 	// Build response
 	resp := KeygenResponse{
-		DID:       keypair.DID,
-		Algorithm: keypair.Algorithm,
-		PublicJWK: string(keypair.PublicJWK),
+		DID:       doc.DID,
+		Algorithm: key.Algorithm,
+		PublicJWK: string(publicJWK),
 	}
 
 	// Include private key only if explicitly requested
 	if req.ReturnPrivateKey {
-		resp.PrivateKeyPEM = string(keypair.PrivateKeyPEM)
-		logging.Logger.Warn("Private key returned in API response - ensure TLS is enabled", "did", keypair.DID)
+		resp.PrivateKeyPEM = key.PrivateKeyPEM
+		logging.Logger.Warn("Private key returned in API response - ensure TLS is enabled", "did", doc.DID)
 	}
 
 	logging.Logger.Info("Generated new DID",
-		"did", keypair.DID,
-		"algorithm", keypair.Algorithm,
+		"did", doc.DID,
+		"algorithm", key.Algorithm,
 		"private_key_returned", req.ReturnPrivateKey)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/keystore/did_keystore.go
+++ b/internal/keystore/did_keystore.go
@@ -1,0 +1,64 @@
+package keystore
+
+import (
+	"crypto"
+	"fmt"
+	"os"
+
+	"github.com/bradtumy/credential-service/internal/did"
+)
+
+// FileBackedKeyStore loads signing keys from the DID FileStore.
+type FileBackedKeyStore struct {
+	store *did.FileStore
+}
+
+// Path returns the underlying store path.
+func (f *FileBackedKeyStore) Path() string {
+	return f.store.Path()
+}
+
+// NewFileBackedKeyStore constructs a FileBackedKeyStore for the given path.
+func NewFileBackedKeyStore(path string) (*FileBackedKeyStore, error) {
+	store := did.NewFileStore(path)
+	if err := store.Load(); err != nil {
+		return nil, err
+	}
+
+	return &FileBackedKeyStore{store: store}, nil
+}
+
+// NewFileBackedKeyStoreFromEnv builds a FileBackedKeyStore using DID_STORE_PATH or the default path.
+func NewFileBackedKeyStoreFromEnv() (*FileBackedKeyStore, error) {
+	path := os.Getenv("DID_STORE_PATH")
+	if path == "" {
+		path = did.DefaultStorePath()
+	}
+	return NewFileBackedKeyStore(path)
+}
+
+// GetSigningKey returns the current signer for the tenant, creating one if needed.
+func (f *FileBackedKeyStore) GetSigningKey(tenantID string) (crypto.Signer, error) {
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenantID is required")
+	}
+
+	doc, ok := f.store.Get(tenantID)
+	if !ok {
+		var err error
+		doc, err = did.NewDIDJWK()
+		if err != nil {
+			return nil, fmt.Errorf("generate did document: %w", err)
+		}
+		if err := f.store.Save(tenantID, doc); err != nil {
+			return nil, fmt.Errorf("persist did document: %w", err)
+		}
+	}
+
+	signer, err := doc.CurrentSigner()
+	if err != nil {
+		return nil, fmt.Errorf("load signer: %w", err)
+	}
+
+	return signer, nil
+}

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -2,10 +2,10 @@ package keystore
 
 import (
 	"crypto"
-	"crypto/ed25519"
-	"crypto/rand"
 	"fmt"
 	"sync"
+
+	"github.com/bradtumy/credential-service/internal/did"
 )
 
 // KeyStore abstracts retrieval of signing keys for tenants.
@@ -17,12 +17,14 @@ type KeyStore interface {
 type MemoryKeyStore struct {
 	mu   sync.Mutex
 	keys map[string]crypto.Signer
+	dids map[string]did.DIDDocument
 }
 
 // NewMemoryKeyStore constructs a MemoryKeyStore instance.
 func NewMemoryKeyStore() *MemoryKeyStore {
 	return &MemoryKeyStore{
 		keys: make(map[string]crypto.Signer),
+		dids: make(map[string]did.DIDDocument),
 	}
 }
 
@@ -39,19 +41,17 @@ func (m *MemoryKeyStore) GetSigningKey(tenantID string) (crypto.Signer, error) {
 		return signer, nil
 	}
 
-	// Generate secure random key for production use
-	// Note: For production, keys should be loaded from secure storage (KMS/HSM)
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	doc, err := did.NewDIDJWK()
 	if err != nil {
-		return nil, fmt.Errorf("generate ed25519 key: %w", err)
+		return nil, fmt.Errorf("generate did document: %w", err)
 	}
 
-	// TODO: For deterministic testing, use environment variable:
-	// if os.Getenv("DETERMINISTIC_KEYS") == "true" {
-	//     seed := sha256.Sum256([]byte("test-seed-" + tenantID))
-	//     priv = ed25519.NewKeyFromSeed(seed[:])
-	// }
+	signer, err := doc.CurrentSigner()
+	if err != nil {
+		return nil, fmt.Errorf("load signer from did: %w", err)
+	}
 
-	m.keys[tenantID] = priv
-	return priv, nil
+	m.keys[tenantID] = signer
+	m.dids[tenantID] = doc
+	return signer, nil
 }

--- a/services/issuer/server.go
+++ b/services/issuer/server.go
@@ -47,8 +47,14 @@ func NewServer(ctx context.Context, cfg config.IssuerConfig) (*Server, error) {
 		store = productionStore
 		log.Printf("Using production keystore with backend: %s", productionStore.GetBackend())
 	} else {
-		store = keystore.NewMemoryKeyStore()
-		log.Printf("Using memory keystore (development mode)")
+		fileStore, err := keystore.NewFileBackedKeyStoreFromEnv()
+		if err != nil {
+			log.Printf("Using memory keystore (development mode, file store unavailable: %v)", err)
+			store = keystore.NewMemoryKeyStore()
+		} else {
+			store = fileStore
+			log.Printf("Using file-backed keystore at %s", fileStore.Path())
+		}
 	}
 
 	tenantStore := tenant.NewMemoryStore()

--- a/services/verifier/server.go
+++ b/services/verifier/server.go
@@ -110,8 +110,14 @@ func NewServer(ctx context.Context, cfg config.VerifierConfig) (*Server, error) 
 		store = productionStore
 		log.Printf("Using production keystore with backend: %s", productionStore.GetBackend())
 	} else {
-		store = keystore.NewMemoryKeyStore()
-		log.Printf("Using memory keystore (development mode)")
+		fileStore, err := keystore.NewFileBackedKeyStoreFromEnv()
+		if err != nil {
+			log.Printf("Using memory keystore (development mode, file store unavailable: %v)", err)
+			store = keystore.NewMemoryKeyStore()
+		} else {
+			store = fileStore
+			log.Printf("Using file-backed keystore at %s", fileStore.Path())
+		}
 	}
 
 	signer, err := store.GetSigningKey(cfg.DefaultTenantID)


### PR DESCRIPTION
## Summary
- add a reusable internal did toolkit for did:jwk generation, export/import, and key rotation with a simple file store
- wire the issuer/verifier services, HTTP keygen handler, and CLI tools to use the new toolkit with optional file-backed keystore support
- document did:jwk usage and CLI flows for creating, exporting, importing, and rotating local DIDs

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347751bfb0832ca3a7056ab1f94480)