### PR TITLE
Define gateway error model and document API

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ A Go-based microservice stack for issuing JWT-encoded VCs, verifying delegation 
   }
   ```
 - **RFC 7638 JWK Thumbprints:** Key identifiers (`kid`) are computed using RFC 7638 JWK Thumbprint for standards-compliant key identification.
-- **Gateway & Synthetic JWTs:** `/v1/gateway/authorize` returns an allow/deny decision and can mint a short-lived JWT so downstream services can keep using `Authorization: Bearer <token>`.
+- **Gateway & Synthetic JWTs:** `/v1/gateway/authorize` returns an allow/deny decision and can mint a short-lived JWT so downstream services can keep using `Authorization: Bearer <token>`. See [Gateway Authorization API](docs/GATEWAY.md) for request/response shapes and error codes.
 - **Tenancy:** `X-Tenant-ID` header (or the default tenant in single-tenant mode) scopes trust registries and policies; Docker Compose runs in single-tenant mode by default.
 - **Policy Evaluation:** Requests are authorized against tenant policies using action/resource matching plus optional scope/claim conditions.
 

--- a/docs/GATEWAY.md
+++ b/docs/GATEWAY.md
@@ -1,0 +1,110 @@
+# Gateway Authorization API
+
+The gateway exposes a single authorization endpoint that evaluates verifiable credentials against trust rules and authorization policies.
+
+## Endpoint
+
+`POST /v1/gateway/authorize`
+
+### Purpose
+- Verifies VC-JWT and SD-JWT credential chains.
+- Ensures issuers are trusted for the tenant.
+- Applies authorization policies (resource + action checks).
+- Optionally mints a short-lived synthetic JWT for downstream services.
+
+## Request Schema
+
+```json
+{
+  "credential": "<string>",
+  "credentials": ["<string>"],
+  "expected_audience": "<string>",
+  "want_synthetic_jwt": false,
+  "resource": "<string>",
+  "action": "<string>"
+}
+```
+
+Notes:
+- Provide either `credential` (single token) or `credentials` (delegation chain). An error is returned if neither is present.
+- `expected_audience` is checked on the final credential in the chain.
+- `resource` and `action` drive policy evaluation and are required.
+- Set `want_synthetic_jwt` to `true` to receive a minted token on allow.
+
+## Response Schema
+
+### Success (HTTP 200)
+
+```json
+{
+  "allowed": true,
+  "subject": "did:example:subject",
+  "acting_on_behalf_of": "did:example:parent",
+  "delegation_depth": 1,
+  "claims": {
+    "scope": ["read"]
+  },
+  "synthetic_jwt": "<token>",
+  "policy_id": 42,
+  "agent": {
+    "acting_on_behalf_of": "did:example:parent",
+    "delegation_depth": 1,
+    "scope": ["read"]
+  },
+  "tenant_id": "tenant",
+  "api_version": "v1"
+}
+```
+
+Fields without values are omitted. Synthetic JWTs are included only when requested and allowed.
+
+### Error (HTTP 4xx/5xx)
+
+```json
+{
+  "allowed": false,
+  "error_code": "policy_denied",
+  "message": "Policy evaluation failed for resource /orders",
+  "details": {
+    "policy_id": 42
+  },
+  "tenant_id": "tenant",
+  "api_version": "v1"
+}
+```
+
+- `allowed` is always present.
+- `error_code` conveys the canonical reason.
+- `message` is human-readable context.
+- `details` is optional diagnostic data (e.g., policy id or underlying error text).
+
+## Error Codes
+
+| Code | Meaning | Typical HTTP Status |
+| --- | --- | --- |
+| `invalid_request` | Malformed or missing inputs. | 400 |
+| `invalid_credential` | Signature failure, malformed token, audience mismatch, or missing SD-JWT disclosure. | 401 |
+| `credential_expired` | The leaf credential in the chain is expired. | 401 |
+| `credential_revoked` | Credential is revoked (when revocation checks are enabled). | 401 |
+| `delegation_invalid` | Delegation depth, scope, or TTL violates parent constraints. | 401 |
+| `issuer_not_trusted` | Issuer is not trusted for the tenant. | 401 |
+| `tenant_mismatch` | Credential tenant does not match the request tenant. | 401 |
+| `policy_denied` | Policies evaluated and denied access. | 403 |
+| `rate_limited` | Rate limit exceeded. | 429 |
+| `policy_error` | Internal policy engine failure. | 500 |
+| `internal_error` | Unhandled server-side failure. | 500 |
+
+## Status Codes
+- **200**: Authorization allowed.
+- **400**: Validation/shape errors.
+- **401**: Credential/issuer/delegation issues.
+- **403**: Policy denial.
+- **429**: Rate limiting.
+- **500**: Internal errors (including policy evaluation failures or synthetic JWT minting issues).
+
+## Caching and Rate Limiting
+- Gateway decisions may be cached when enabled; cached responses retain the same shape and error codes.
+- Rate limiting uses client IP + tenant; exceeded limits return `rate_limited`.
+
+## Versioning
+`api_version` is included on all responses for forward compatibility.

--- a/internal/httpserver/gateway_handlers.go
+++ b/internal/httpserver/gateway_handlers.go
@@ -36,11 +36,14 @@ type GatewayAuthorizeResponse struct {
 	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
 	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
 	Claims           map[string]interface{} `json:"claims,omitempty"`
-	Reason           string                 `json:"reason,omitempty"`
 	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
 	Agent            *AgentContext          `json:"agent,omitempty"`
 	TenantID         string                 `json:"tenant_id,omitempty"`
 	PolicyID         *int64                 `json:"policy_id,omitempty"`
+	ErrorCode        string                 `json:"error_code,omitempty"`
+	Message          string                 `json:"message,omitempty"`
+	Details          map[string]any         `json:"details,omitempty"`
+	Reason           string                 `json:"reason,omitempty"`
 	APIVersion       string                 `json:"api_version"`
 }
 
@@ -94,27 +97,26 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 
 	mux.HandleFunc("/v1/gateway/authorize", func(w http.ResponseWriter, r *http.Request) {
 		started := time.Now()
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = cfg.DefaultTenantID
+		}
 		if r.Method != http.MethodPost {
-			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			writeGatewayError(w, tenantID, gatewayError{status: http.StatusMethodNotAllowed, code: "method_not_allowed", message: "method not allowed"})
 			return
 		}
 
 		var req GatewayAuthorizeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			WriteAPIError(w, http.StatusBadRequest, "bad_request", "invalid request payload")
+			writeGatewayError(w, tenantID, gatewayError{status: http.StatusBadRequest, code: "invalid_request", message: "invalid request payload"})
 			return
-		}
-
-		tenantID := TenantIDFromContext(r.Context())
-		if tenantID == "" {
-			tenantID = cfg.DefaultTenantID
 		}
 
 		cfg.Metrics.IncAuthzRequest(tenantID)
 
 		if err := validateGatewayRequest(req); err != nil {
 			cfg.Metrics.IncAuthzDeny(tenantID, "invalid_request")
-			WriteAPIError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			writeGatewayError(w, tenantID, gatewayError{status: http.StatusBadRequest, code: "invalid_request", message: err.Error()})
 			return
 		}
 
@@ -130,7 +132,7 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 		}
 		if !allowed {
 			cfg.Metrics.IncAuthzDeny(tenantID, "rate_limited")
-			WriteAPIError(w, http.StatusTooManyRequests, "rate_limited", "rate limit exceeded")
+			writeGatewayError(w, tenantID, gatewayError{status: http.StatusTooManyRequests, code: "rate_limited", message: "rate limit exceeded"})
 			return
 		}
 
@@ -138,11 +140,15 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 		if cached, ok := readCachedDecision(cfg.DecisionCache, cacheKey); ok {
 			cfg.Metrics.IncAuthzCacheHit(tenantID)
 			logGatewayDecision(started, tenantID, cached, true)
-			writeDecision(w, cached)
+			writeGatewayDecision(w, cached)
 			if cached.Allowed {
 				cfg.Metrics.IncAuthzAllow(tenantID)
 			} else {
-				cfg.Metrics.IncAuthzDeny(tenantID, cached.Reason)
+				denyReason := cached.ErrorCode
+				if denyReason == "" {
+					denyReason = cached.Reason
+				}
+				cfg.Metrics.IncAuthzDeny(tenantID, denyReason)
 			}
 			return
 		}
@@ -166,12 +172,11 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 
 		chainResult, err := domain.VerifyCredentialChain(tokens, deps, domain.VerificationOptions{ExpectedAudience: req.ExpectedAudience, MaxDelegationDepth: 3}, cfg.Now())
 		if err != nil {
-			reason := mapVerificationErrorToReason(err)
-			metrics.DefaultVerifierMetrics.IncVerificationFailure(reason)
-			resp := GatewayAuthorizeResponse{Allowed: false, Reason: reason, APIVersion: version.APIVersion, TenantID: tenantID}
-			cfg.Metrics.IncAuthzDeny(tenantID, reason)
+			gwErr := mapVerificationError(err)
+			metrics.DefaultVerifierMetrics.IncVerificationFailure(gwErr.code)
+			cfg.Metrics.IncAuthzDeny(tenantID, gwErr.code)
+			resp := writeGatewayError(w, tenantID, gwErr)
 			logGatewayDecision(started, tenantID, resp, false)
-			writeDecision(w, resp)
 			return
 		}
 
@@ -192,14 +197,15 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 
 		policyResult, err := cfg.PolicyEngine.Evaluate(evalInput)
 		if err != nil {
-			WriteAPIError(w, http.StatusInternalServerError, "policy_error", err.Error())
+			gwErr := gatewayError{status: http.StatusInternalServerError, code: "policy_error", message: err.Error()}
+			writeGatewayError(w, tenantID, gwErr)
 			return
 		}
 		if !policyResult.Allow {
 			cfg.Metrics.IncAuthzDeny(tenantID, "policy_denied")
-			denyResp := GatewayAuthorizeResponse{Allowed: false, Reason: "policy_denied", TenantID: tenantID, PolicyID: policyResult.PolicyID, APIVersion: version.APIVersion}
+			denyResp := GatewayAuthorizeResponse{Allowed: false, ErrorCode: "policy_denied", Message: policyResult.Reason, Details: map[string]any{"policy_id": policyResult.PolicyID}, Reason: "policy_denied", TenantID: tenantID, PolicyID: policyResult.PolicyID, APIVersion: version.APIVersion}
 			logGatewayDecision(started, tenantID, denyResp, false)
-			writeDecision(w, denyResp)
+			writeGatewayDecision(w, denyResp)
 			return
 		}
 		var agentContext *AgentContext
@@ -230,9 +236,9 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 		if req.WantSyntheticJWT {
 			jwt, err := domain.BuildSyntheticJWT(decision, cfg.SigningKey, cfg.JWTIssuer, 15*time.Minute)
 			if err != nil {
-				resp := GatewayAuthorizeResponse{Allowed: false, Reason: "jwt_error", APIVersion: version.APIVersion, TenantID: tenantID}
+				resp := GatewayAuthorizeResponse{Allowed: false, ErrorCode: "internal_error", Message: "failed to mint synthetic jwt", Details: map[string]any{"error": err.Error()}, Reason: "jwt_error", APIVersion: version.APIVersion, TenantID: tenantID}
 				cfg.Metrics.IncAuthzDeny(tenantID, "jwt_error")
-				writeDecision(w, resp)
+				writeGatewayDecision(w, resp)
 				return
 			}
 			response.SyntheticJWT = jwt.Token
@@ -243,38 +249,78 @@ func RegisterGatewayRoutes(mux *http.ServeMux, cfg *GatewayConfig) {
 		ttl := computeDecisionTTL(chainResult, cfg.Now())
 		persistDecision(cfg.DecisionCache, cacheKey, response, ttl)
 		logGatewayDecision(started, tenantID, response, false)
-		writeDecision(w, response)
+		writeGatewayDecision(w, response)
 	})
 }
 
-func writeDecision(w http.ResponseWriter, resp GatewayAuthorizeResponse) {
-	w.Header().Set("Content-Type", "application/json")
-	status := http.StatusOK
-	if !resp.Allowed {
-		status = http.StatusForbidden
+type gatewayError struct {
+	status  int
+	code    string
+	message string
+	details map[string]any
+}
+
+func writeGatewayDecision(w http.ResponseWriter, resp GatewayAuthorizeResponse) {
+	writeGatewayResponse(w, statusForGatewayResponse(resp), resp)
+}
+
+func writeGatewayError(w http.ResponseWriter, tenantID string, err gatewayError) GatewayAuthorizeResponse {
+	resp := GatewayAuthorizeResponse{
+		Allowed:    false,
+		ErrorCode:  err.code,
+		Message:    err.message,
+		Details:    err.details,
+		Reason:     err.code,
+		TenantID:   tenantID,
+		APIVersion: version.APIVersion,
 	}
+	writeGatewayResponse(w, err.status, resp)
+	return resp
+}
+
+func writeGatewayResponse(w http.ResponseWriter, status int, resp GatewayAuthorizeResponse) {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func mapVerificationErrorToReason(err error) string {
+func statusForGatewayResponse(resp GatewayAuthorizeResponse) int {
+	if resp.Allowed {
+		return http.StatusOK
+	}
+
+	switch resp.ErrorCode {
+	case "invalid_request":
+		return http.StatusBadRequest
+	case "rate_limited":
+		return http.StatusTooManyRequests
+	case "policy_denied":
+		return http.StatusForbidden
+	case "credential_expired", "invalid_credential", "delegation_invalid", "issuer_not_trusted", "credential_revoked", "tenant_mismatch":
+		return http.StatusUnauthorized
+	case "policy_error", "internal_error":
+		return http.StatusInternalServerError
+	}
+
+	if resp.Reason == "jwt_error" {
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusForbidden
+}
+
+func mapVerificationError(err error) gatewayError {
 	switch {
 	case errors.Is(err, domain.ErrExpiredCredential):
-		return "expired_credential"
+		return gatewayError{status: http.StatusUnauthorized, code: "credential_expired", message: "credential has expired"}
 	case errors.Is(err, domain.ErrUntrustedIssuer):
-		return "untrusted_issuer"
-	case errors.Is(err, domain.ErrInvalidSignature):
-		return "invalid_signature"
-	case errors.Is(err, domain.ErrUnexpectedAudience):
-		return "unexpected_audience"
-	case errors.Is(err, domain.ErrDelegationDepth):
-		return "delegation_depth_exceeded"
-	case errors.Is(err, domain.ErrDelegationScope):
-		return "invalid_scope"
-	case errors.Is(err, domain.ErrDelegationTTL):
-		return "invalid_ttl"
+		return gatewayError{status: http.StatusUnauthorized, code: "issuer_not_trusted", message: "issuer is not trusted"}
+	case errors.Is(err, domain.ErrInvalidSignature), errors.Is(err, domain.ErrInvalidToken), errors.Is(err, domain.ErrIssuedInFuture), errors.Is(err, domain.ErrUnexpectedAudience), errors.Is(err, domain.ErrMissingDisclosure), errors.Is(err, domain.ErrInvalidDisclosure):
+		return gatewayError{status: http.StatusUnauthorized, code: "invalid_credential", message: err.Error()}
+	case errors.Is(err, domain.ErrDelegationDepth), errors.Is(err, domain.ErrDelegationScope), errors.Is(err, domain.ErrDelegationTTL), errors.Is(err, domain.ErrInvalidDelegation):
+		return gatewayError{status: http.StatusUnauthorized, code: "delegation_invalid", message: err.Error()}
 	default:
-		return "verification_failed"
+		return gatewayError{status: http.StatusInternalServerError, code: "internal_error", message: "credential verification failed", details: map[string]any{"error": err.Error()}}
 	}
 }
 

--- a/internal/httpserver/gateway_handlers_test.go
+++ b/internal/httpserver/gateway_handlers_test.go
@@ -160,14 +160,14 @@ func TestGatewayAuthorizeDenyExpired(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
 	}
 
 	var resp GatewayAuthorizeResponse
 	_ = json.NewDecoder(rr.Body).Decode(&resp)
 
-	if resp.Allowed || resp.Reason != "expired_credential" {
+	if resp.Allowed || resp.ErrorCode != "credential_expired" {
 		t.Fatalf("unexpected deny response: %+v", resp)
 	}
 }
@@ -197,13 +197,13 @@ func TestGatewayAuthorizeUntrustedIssuer(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
 	}
 
 	var resp GatewayAuthorizeResponse
 	_ = json.NewDecoder(rr.Body).Decode(&resp)
-	if resp.Allowed || resp.Reason != "untrusted_issuer" {
+	if resp.Allowed || resp.ErrorCode != "issuer_not_trusted" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 }
@@ -355,7 +355,7 @@ func TestGatewayAuthorizePolicyDeny(t *testing.T) {
 	}
 	var resp GatewayAuthorizeResponse
 	_ = json.NewDecoder(rr.Body).Decode(&resp)
-	if resp.Allowed || resp.Reason != "policy_denied" {
+	if resp.Allowed || resp.ErrorCode != "policy_denied" {
 		t.Fatalf("expected policy deny, got %+v", resp)
 	}
 }
@@ -417,7 +417,7 @@ func TestGatewayAuthorizePolicyDefaultDeny(t *testing.T) {
 	}
 	var resp GatewayAuthorizeResponse
 	_ = json.NewDecoder(rr.Body).Decode(&resp)
-	if resp.Allowed || resp.Reason != "policy_denied" {
+	if resp.Allowed || resp.ErrorCode != "policy_denied" {
 		t.Fatalf("expected default policy deny, got %+v", resp)
 	}
 }

--- a/test/integration/gateway_authorize_test.go
+++ b/test/integration/gateway_authorize_test.go
@@ -57,8 +57,8 @@ func TestGatewayAuthorize_UntrustedIssuer(t *testing.T) {
 
 	mux.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for untrusted issuer, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for untrusted issuer, got %d", rr.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Standardize gateway authorize error responses with shared helpers, canonical error codes, and consistent HTTP statuses.
- Update gateway authorization tests to assert the new error codes for expired credentials, untrusted issuers, and policy denials.
- Document the gateway authorization contract in docs/GATEWAY.md and link it from the README.

## Testing
- `GOPROXY=https://proxy.golang.org,direct go test -v ./internal/httpserver -run GatewayAuthorize -count=1`
- `GOPROXY=https://proxy.golang.org,direct go test ./test/integration -run GatewayAuthorize -count=1`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347c7a1be8832cacc3a03788089602)