### PR TITLE
Enhance Go SDK client and examples

### DIFF
--- a/examples/go/basic/main.go
+++ b/examples/go/basic/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	sdk "github.com/bradtumy/credential-service/sdk-go"
+)
+
+func main() {
+	client := sdk.NewClientFromEnv()
+	if client.IssuerURL == "" || client.VerifierURL == "" {
+		log.Fatal("ISSUER_URL and VERIFIER_URL (or GATEWAY_URL) must be set")
+	}
+	if client.GatewayURL == "" {
+		client.GatewayURL = client.VerifierURL
+	}
+
+	issued, err := client.IssueVC(context.Background(), sdk.IssueRequest{
+		SubjectDID: "did:example:alice",
+		TTLSeconds: 600,
+		Claims:     map[string]any{"aud": "sample-api", "role": "member"},
+	})
+	if err != nil {
+		log.Fatalf("issue failed: %v", err)
+	}
+	fmt.Println("Issued VC-JWT:", issued.Credential)
+
+	verified, err := client.Verify(context.Background(), issued.Credential)
+	if err != nil {
+		log.Fatalf("verify failed: %v", err)
+	}
+	fmt.Printf("Verified subject=%s valid=%v\n", verified.Subject, verified.Valid)
+
+	decision, err := client.Authorize(context.Background(), sdk.AuthorizeRequest{
+		Credential:       issued.Credential,
+		ExpectedAudience: "sample-api",
+		WantSyntheticJWT: true,
+	})
+	if err != nil {
+		log.Fatalf("authorize failed: %v", err)
+	}
+	if !decision.Allowed {
+		log.Fatalf("not authorized: %s", decision.Reason)
+	}
+	fmt.Println("Synthetic JWT:", decision.SyntheticJWT)
+
+	if err := callSampleAPI(decision.SyntheticJWT); err != nil {
+		log.Fatalf("sample API call failed: %v", err)
+	}
+}
+
+func callSampleAPI(token string) error {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8090/api/resource", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return err
+	}
+
+	pretty, _ := json.MarshalIndent(body, "", "  ")
+	fmt.Fprintf(os.Stdout, "Sample API response:\n%s\n", string(pretty))
+	return nil
+}

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,14 +1,14 @@
 # Credential Service Go SDK
 
-A lightweight Go client for issuing, delegating, verifying, and authorizing Verifiable Credentials with the Credential Service.
+A first-class Go client for issuing, verifying, and authorizing credentials with the Credential Service.
 
 ## Installation
 
 ```bash
-go get github.com/bradtumy/credential-service/sdk/go
+go get github.com/bradtumy/credential-service/sdk-go
 ```
 
-## Usage
+## Quickstart
 
 ```go
 package main
@@ -17,31 +17,37 @@ import (
     "context"
     "log"
 
-    sdk "github.com/bradtumy/credential-service/sdk/go"
+    sdk "github.com/bradtumy/credential-service/sdk-go"
 )
 
 func main() {
-    client := &sdk.Client{BaseURL: "http://localhost:8080"}
-    issued, err := client.IssueCredential(context.Background(), sdk.IssueRequest{
+    client := sdk.NewLocalDevClient()
+
+    issued, err := client.IssueVC(context.Background(), sdk.IssueRequest{
         SubjectDID: "did:example:alice",
         TTLSeconds: 600,
-        Claims: map[string]interface{}{"aud": "example-api"},
+        Claims: map[string]any{"aud": "sample-api"},
     })
     if err != nil {
         log.Fatalf("issue failed: %v", err)
     }
 
-    decision, err := client.GatewayAuthorize(context.Background(), sdk.GatewayAuthorizeRequest{
+    verified, err := client.Verify(context.Background(), issued.Credential)
+    if err != nil {
+        log.Fatalf("verify failed: %v", err)
+    }
+    log.Printf("valid=%v subject=%s", verified.Valid, verified.Subject)
+
+    decision, err := client.Authorize(context.Background(), sdk.AuthorizeRequest{
         Credential:       issued.Credential,
-        ExpectedAudience: "example-api",
+        ExpectedAudience: "sample-api",
         WantSyntheticJWT: true,
     })
     if err != nil {
         log.Fatalf("authorize failed: %v", err)
     }
-
-    log.Printf("allowed=%v subject=%s acting_for=%s synthetic_jwt=%s", decision.Allowed, decision.Subject, decision.ActingOnBehalfOf, decision.SyntheticJWT)
+    log.Printf("allowed=%v synthetic_jwt=%s", decision.Allowed, decision.SyntheticJWT)
 }
 ```
 
-See the repository root `README.md` for the 5-minute quickstart and more examples.
+For end-to-end flows and service details, see the repository root `README.md` and the docs directory.

--- a/sdk/go/agent.go
+++ b/sdk/go/agent.go
@@ -102,8 +102,8 @@ func (a *AgentClient) CallAuthorized(ctx context.Context, session *AgentSession,
 		}
 	}
 
-	req := GatewayAuthorizeRequest{Credentials: []string{session.ParentToken, session.AccessToken}, WantSyntheticJWT: true}
-	decision, err := a.SDK.GatewayAuthorize(ctx, req)
+	req := AuthorizeRequest{Credentials: []string{session.ParentToken, session.AccessToken}, WantSyntheticJWT: true}
+	decision, err := a.SDK.Authorize(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/agent_test.go
+++ b/sdk/go/agent_test.go
@@ -33,7 +33,7 @@ func TestAgentSessionLifecycle(t *testing.T) {
 			resp := DelegateResponse{Credential: buildToken(t, credentialPayload{Subject: "did:agent", ExpiresAt: now.Add(30 * time.Minute), Claims: map[string]interface{}{"scope": []string{"read"}}})}
 			_ = json.NewEncoder(w).Encode(resp)
 		case "/v1/gateway/authorize":
-			_ = json.NewEncoder(w).Encode(GatewayAuthorizeResponse{Allowed: true, SyntheticJWT: "synthetic.jwt.token"})
+			_ = json.NewEncoder(w).Encode(AuthorizeResponse{Allowed: true, SyntheticJWT: "synthetic.jwt.token"})
 		case "/resource":
 			if got := r.Header.Get("Authorization"); got != "Bearer synthetic.jwt.token" {
 				t.Fatalf("unexpected auth header: %s", got)
@@ -46,7 +46,7 @@ func TestAgentSessionLifecycle(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	client := &Client{IssuerURL: server.URL, VerifierURL: server.URL, GatewayURL: server.URL, HTTPClient: server.Client()}
 	agent := &AgentClient{SDK: client}
 
 	session, err := agent.StartAgentSession(context.Background(), parentToken, "did:agent", []string{"read"}, 45*time.Minute)
@@ -78,7 +78,7 @@ func TestAgentRefreshOnExpiry(t *testing.T) {
 			resp := DelegateResponse{Credential: buildToken(t, credentialPayload{Subject: "did:agent", ExpiresAt: now.Add(time.Duration(refreshCount) * 10 * time.Minute), Claims: map[string]interface{}{"scope": []string{"read"}}})}
 			_ = json.NewEncoder(w).Encode(resp)
 		case "/v1/gateway/authorize":
-			_ = json.NewEncoder(w).Encode(GatewayAuthorizeResponse{Allowed: true, SyntheticJWT: "synthetic.jwt.token"})
+			_ = json.NewEncoder(w).Encode(AuthorizeResponse{Allowed: true, SyntheticJWT: "synthetic.jwt.token"})
 		case "/resource":
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -87,7 +87,7 @@ func TestAgentRefreshOnExpiry(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	client := &Client{BaseURL: server.URL, HTTPClient: server.Client()}
+	client := &Client{IssuerURL: server.URL, VerifierURL: server.URL, GatewayURL: server.URL, HTTPClient: server.Client()}
 	agent := &AgentClient{SDK: client}
 
 	session, err := agent.StartAgentSession(context.Background(), parentToken, "did:agent", []string{"read"}, 5*time.Minute)

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -4,17 +4,98 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
 
-// Client is a lightweight HTTP client for the credential services.
+// Client is the entry point for interacting with the credential-service APIs.
+//
+// Configure the service URLs explicitly or use the helpers NewLocalDevClient and
+// NewClientFromEnv to populate sensible defaults.
 type Client struct {
-	BaseURL    string
-	HTTPClient *http.Client
+	IssuerURL   string
+	VerifierURL string
+	GatewayURL  string
+	HTTPClient  *http.Client
+}
+
+// NewClientFromEnv builds a client using environment variables commonly used by
+// local development and deployment scripts.
+func NewClientFromEnv() *Client {
+	return &Client{
+		IssuerURL:   os.Getenv("ISSUER_URL"),
+		VerifierURL: os.Getenv("VERIFIER_URL"),
+		GatewayURL:  os.Getenv("GATEWAY_URL"),
+	}
+}
+
+// NewLocalDevClient returns a client preconfigured to talk to services started
+// via `make dev` or `docker-compose up`.
+func NewLocalDevClient() *Client {
+	return &Client{
+		IssuerURL:   "http://localhost:8080",
+		VerifierURL: "http://localhost:8081",
+		GatewayURL:  "http://localhost:8081",
+	}
+}
+
+// IssueVC mints a standard VC-JWT credential using the issuer service.
+func (c *Client) IssueVC(ctx context.Context, req IssueRequest) (IssueResponse, error) {
+	req.Format = "jwt-vc"
+	return c.issue(ctx, req)
+}
+
+// IssueSDJWT mints an SD-JWT credential with disclosures using the issuer service.
+func (c *Client) IssueSDJWT(ctx context.Context, req IssueRequest) (IssueResponse, error) {
+	req.Format = "sd-jwt"
+	return c.issue(ctx, req)
+}
+
+func (c *Client) issue(ctx context.Context, req IssueRequest) (IssueResponse, error) {
+	var resp IssueResponse
+	if err := c.post(ctx, c.IssuerURL, "/v1/credentials/issue", req, &resp); err != nil {
+		return IssueResponse{}, err
+	}
+	return resp, nil
+}
+
+// Verify checks a credential or chain using the verifier service.
+func (c *Client) Verify(ctx context.Context, credential string) (VerifyResponse, error) {
+	payload := VerifyRequest{Credential: credential}
+	var resp VerifyResponse
+	if err := c.post(ctx, c.VerifierURL, "/v1/credentials/verify", payload, &resp); err != nil {
+		return VerifyResponse{}, err
+	}
+	return resp, nil
+}
+
+// Authorize validates credentials and returns an allow/deny decision plus an
+// optional synthetic JWT for downstream services.
+func (c *Client) Authorize(ctx context.Context, req AuthorizeRequest) (AuthorizeResponse, error) {
+	base := c.GatewayURL
+	if base == "" {
+		base = c.VerifierURL
+	}
+
+	var resp AuthorizeResponse
+	if err := c.post(ctx, base, "/v1/gateway/authorize", req, &resp); err != nil {
+		return AuthorizeResponse{}, err
+	}
+	return resp, nil
+}
+
+// DelegateCredential calls the delegation endpoint to mint a delegated credential.
+func (c *Client) DelegateCredential(ctx context.Context, req DelegateRequest) (DelegateResponse, error) {
+	var resp DelegateResponse
+	if err := c.post(ctx, c.IssuerURL, "/v1/credentials/delegate", req, &resp); err != nil {
+		return DelegateResponse{}, err
+	}
+	return resp, nil
 }
 
 func (c *Client) httpClient() *http.Client {
@@ -24,21 +105,29 @@ func (c *Client) httpClient() *http.Client {
 	return &http.Client{Timeout: 15 * time.Second}
 }
 
-func (c *Client) buildURL(path string) string {
-	base := strings.TrimSuffix(c.BaseURL, "/")
-	if strings.HasPrefix(path, "/") {
-		return base + path
+func buildURL(base, path string) (string, error) {
+	if base == "" {
+		return "", errors.New("base URL is required")
 	}
-	return base + "/" + path
+	trimmed := strings.TrimSuffix(base, "/")
+	if strings.HasPrefix(path, "/") {
+		return trimmed + path, nil
+	}
+	return trimmed + "/" + path, nil
 }
 
-func (c *Client) post(ctx context.Context, path string, payload interface{}, out interface{}) error {
+func (c *Client) post(ctx context.Context, baseURL, path string, payload interface{}, out interface{}) error {
+	fullURL, err := buildURL(baseURL, path)
+	if err != nil {
+		return err
+	}
+
 	bodyBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildURL(path), bytes.NewReader(bodyBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -52,11 +141,11 @@ func (c *Client) post(ctx context.Context, path string, payload interface{}, out
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		return mapStatusToError(resp.StatusCode)
+		return decodeAPIError(resp)
 	}
 
 	if out == nil {
-		io.Copy(io.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 
@@ -65,4 +154,12 @@ func (c *Client) post(ctx context.Context, path string, payload interface{}, out
 		return fmt.Errorf("decode response: %w", err)
 	}
 	return nil
+}
+
+func decodeAPIError(resp *http.Response) error {
+	var apiErr APIError
+	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Error != "" {
+		return fmt.Errorf("%w: %s", mapStatusToError(resp.StatusCode), apiErr.Error)
+	}
+	return mapStatusToError(resp.StatusCode)
 }

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
+	"time"
 )
 
-func TestIssueCredential(t *testing.T) {
+func TestIssueVCFormatsRequest(t *testing.T) {
 	var captured IssueRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/credentials/issue" {
@@ -22,102 +22,78 @@ func TestIssueCredential(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(IssueResponse{
-			Credential:       "token123",
-			Subject:          captured.SubjectDID,
-			ActingOnBehalfOf: captured.SubjectDID,
-			DelegationDepth:  0,
-			Claims:           captured.Claims,
-		})
+		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: "vc.jwt", Format: captured.Format})
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
-	client := &Client{BaseURL: srv.URL}
-	req := IssueRequest{SubjectDID: "did:example:alice", TTLSeconds: 600, Claims: map[string]interface{}{"aud": "example"}}
-	resp, err := client.IssueCredential(context.Background(), req)
+	client := &Client{IssuerURL: srv.URL}
+	resp, err := client.IssueVC(context.Background(), IssueRequest{SubjectDID: "did:example:1", TTLSeconds: 60})
 	if err != nil {
-		t.Fatalf("IssueCredential returned error: %v", err)
+		t.Fatalf("IssueVC returned error: %v", err)
 	}
-
-	if resp.Credential != "token123" || resp.Subject != "did:example:alice" {
+	if captured.Format != "jwt-vc" {
+		t.Fatalf("expected format jwt-vc, got %s", captured.Format)
+	}
+	if resp.Credential != "vc.jwt" {
 		t.Fatalf("unexpected response: %+v", resp)
-	}
-	if !reflect.DeepEqual(resp.Claims, req.Claims) {
-		t.Fatalf("claims mismatch: %+v", resp.Claims)
-	}
-	if captured.TTLSeconds != req.TTLSeconds {
-		t.Fatalf("ttl mismatch: %d", captured.TTLSeconds)
 	}
 }
 
-func TestDelegateCredential(t *testing.T) {
+func TestIssueSDJWTIncludesDisclosures(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/credentials/delegate" {
+		_ = json.NewEncoder(w).Encode(IssueResponse{Credential: "sd.jwt", Disclosures: []string{"disc"}, Format: "sd-jwt"})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{IssuerURL: srv.URL}
+	resp, err := client.IssueSDJWT(context.Background(), IssueRequest{SubjectDID: "did:example:1", TTLSeconds: 60})
+	if err != nil {
+		t.Fatalf("IssueSDJWT returned error: %v", err)
+	}
+	if resp.Format != "sd-jwt" || len(resp.Disclosures) != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestVerifyUsesVerifierURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/credentials/verify" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(DelegateResponse{Credential: "delegated", DelegationDepth: 1, ActingOnBehalfOf: "did:parent"})
+		_ = json.NewEncoder(w).Encode(VerifyResponse{Valid: true, Subject: "did:sub", DelegationDepth: 0, ExpiresAt: time.Now()})
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
-	client := &Client{BaseURL: srv.URL}
-	resp, err := client.DelegateCredential(context.Background(), DelegateRequest{ParentCredential: "parent", DelegateDID: "did:child", Scope: []string{"read"}, TTLSeconds: 300})
-	if err != nil {
-		t.Fatalf("DelegateCredential returned error: %v", err)
-	}
-	if resp.Credential != "delegated" || resp.DelegationDepth != 1 {
-		t.Fatalf("unexpected response: %+v", resp)
-	}
-}
-
-func TestVerify(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(VerifyResponse{Valid: true, Subject: "did:subject", DelegationDepth: 0, Claims: map[string]interface{}{"role": "admin"}})
-	}))
-	defer srv.Close()
-
-	client := &Client{BaseURL: srv.URL}
+	client := &Client{VerifierURL: srv.URL}
 	resp, err := client.Verify(context.Background(), "token")
 	if err != nil {
 		t.Fatalf("Verify returned error: %v", err)
 	}
-	if !resp.Valid || resp.Subject != "did:subject" {
+	if !resp.Valid || resp.Subject != "did:sub" {
 		t.Fatalf("unexpected response: %+v", resp)
-	}
-	if resp.Claims["role"] != "admin" {
-		t.Fatalf("missing claim role")
 	}
 }
 
-func TestGatewayAuthorize(t *testing.T) {
-	var captured GatewayAuthorizeRequest
+func TestAuthorizeFallsBackToVerifierURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-			t.Fatalf("decode request: %v", err)
+		if r.URL.Path != "/v1/gateway/authorize" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(GatewayAuthorizeResponse{Allowed: true, Subject: "did:subject", ActingOnBehalfOf: "did:parent", DelegationDepth: 1, Claims: map[string]interface{}{"scope": []string{"read"}}, SyntheticJWT: "jwt"})
+		_ = json.NewEncoder(w).Encode(AuthorizeResponse{Allowed: true, SyntheticJWT: "synthetic"})
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
-	client := &Client{BaseURL: srv.URL}
-	req := GatewayAuthorizeRequest{Credential: "token", ExpectedAudience: "api", WantSyntheticJWT: true}
-	resp, err := client.GatewayAuthorize(context.Background(), req)
+	client := &Client{VerifierURL: srv.URL}
+	resp, err := client.Authorize(context.Background(), AuthorizeRequest{Credential: "cred", WantSyntheticJWT: true})
 	if err != nil {
-		t.Fatalf("GatewayAuthorize returned error: %v", err)
+		t.Fatalf("Authorize returned error: %v", err)
 	}
-	if !resp.Allowed || resp.SyntheticJWT != "jwt" {
+	if !resp.Allowed || resp.SyntheticJWT != "synthetic" {
 		t.Fatalf("unexpected response: %+v", resp)
-	}
-	if !captured.WantSyntheticJWT || captured.ExpectedAudience != "api" {
-		t.Fatalf("unexpected request captured: %+v", captured)
 	}
 }
 
-func TestErrorMapping(t *testing.T) {
+func TestDecodeAPIErrorMapsStatus(t *testing.T) {
 	cases := []struct {
 		status int
 		want   error
@@ -131,13 +107,22 @@ func TestErrorMapping(t *testing.T) {
 	for _, tc := range cases {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(tc.status)
+			_ = json.NewEncoder(w).Encode(APIError{Error: "boom"})
 		}))
-		client := &Client{BaseURL: srv.URL}
-		_, err := client.IssueCredential(context.Background(), IssueRequest{SubjectDID: "did:ex", TTLSeconds: 1})
+		client := &Client{IssuerURL: srv.URL}
+		_, err := client.IssueVC(context.Background(), IssueRequest{SubjectDID: "did:ex", TTLSeconds: 1})
 		srv.Close()
 
 		if !errors.Is(err, tc.want) {
 			t.Fatalf("status %d: expected %v got %v", tc.status, tc.want, err)
 		}
+	}
+}
+
+func TestMissingBaseURL(t *testing.T) {
+	client := &Client{}
+	_, err := client.IssueVC(context.Background(), IssueRequest{SubjectDID: "did:ex", TTLSeconds: 1})
+	if err == nil {
+		t.Fatalf("expected error for missing issuer url")
 	}
 }

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/bradtumy/credential-service/sdk/go
+module github.com/bradtumy/credential-service/sdk-go
 
 go 1.22
 

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -1,20 +1,21 @@
 package sdk
 
+import "time"
+
 // IssueRequest represents a request to issue a verifiable credential.
 type IssueRequest struct {
 	SubjectDID string                 `json:"subject_did"`
 	TTLSeconds int64                  `json:"ttl_seconds"`
 	Claims     map[string]interface{} `json:"claims,omitempty"`
+	Format     string                 `json:"format,omitempty"`
 }
 
 // IssueResponse contains the issued credential token and associated metadata.
 type IssueResponse struct {
-	Credential       string                 `json:"credential"`
-	Subject          string                 `json:"subject,omitempty"`
-	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
-	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
-	Claims           map[string]interface{} `json:"claims,omitempty"`
-	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+	Credential  string   `json:"credential"`
+	Disclosures []string `json:"disclosures,omitempty"`
+	Format      string   `json:"format,omitempty"`
+	APIVersion  string   `json:"api_version,omitempty"`
 }
 
 // DelegateRequest represents a delegation issuance request.
@@ -28,12 +29,17 @@ type DelegateRequest struct {
 
 // DelegateResponse contains the delegated credential token and metadata.
 type DelegateResponse struct {
-	Credential       string                 `json:"credential"`
-	Subject          string                 `json:"subject,omitempty"`
-	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
-	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
-	Claims           map[string]interface{} `json:"claims,omitempty"`
-	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+	Credential string `json:"credential"`
+	APIVersion string `json:"api_version,omitempty"`
+}
+
+// VerifyRequest represents a verification request payload.
+type VerifyRequest struct {
+	Credential       string   `json:"credential,omitempty"`
+	Credentials      []string `json:"credentials,omitempty"`
+	ExpectedAudience string   `json:"expected_audience,omitempty"`
+	Disclosures      []string `json:"disclosures,omitempty"`
+	Format           string   `json:"format,omitempty"`
 }
 
 // VerifyResponse represents verification details for a credential chain.
@@ -41,36 +47,46 @@ type VerifyResponse struct {
 	Valid            bool                   `json:"valid"`
 	Subject          string                 `json:"subject"`
 	Issuer           string                 `json:"issuer,omitempty"`
-	ExpiresAt        string                 `json:"expires_at,omitempty"`
+	ExpiresAt        time.Time              `json:"expires_at"`
 	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
-	DelegationDepth  int                    `json:"delegation_depth,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth"`
 	Claims           map[string]interface{} `json:"claims,omitempty"`
 	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+	APIVersion       string                 `json:"api_version,omitempty"`
 }
 
-// GatewayAuthorizeRequest is the payload expected by the gateway authorize endpoint.
-type GatewayAuthorizeRequest struct {
-	Credential       string   `json:"credential"`
-	Credentials      []string `json:"credentials"`
-	ExpectedAudience string   `json:"expected_audience"`
-	WantSyntheticJWT bool     `json:"want_synthetic_jwt"`
+// AuthorizeRequest is the payload expected by the gateway authorize endpoint.
+type AuthorizeRequest struct {
+	Credential       string   `json:"credential,omitempty"`
+	Credentials      []string `json:"credentials,omitempty"`
+	ExpectedAudience string   `json:"expected_audience,omitempty"`
+	WantSyntheticJWT bool     `json:"want_synthetic_jwt,omitempty"`
 }
 
-// GatewayAuthorizeResponse is returned when authorizing a request at the gateway.
-type GatewayAuthorizeResponse struct {
-        Allowed          bool                   `json:"allowed"`
-        Subject          string                 `json:"subject,omitempty"`
-        ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
-        DelegationDepth  int                    `json:"delegation_depth,omitempty"`
-        Claims           map[string]interface{} `json:"claims,omitempty"`
-        Reason           string                 `json:"reason,omitempty"`
-        SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
-        Agent            *GatewayAgentContext   `json:"agent,omitempty"`
+// AuthorizeResponse is returned when authorizing a request at the gateway.
+type AuthorizeResponse struct {
+	Allowed          bool                   `json:"allowed"`
+	Subject          string                 `json:"subject,omitempty"`
+	ActingOnBehalfOf string                 `json:"acting_on_behalf_of,omitempty"`
+	DelegationDepth  int                    `json:"delegation_depth"`
+	Claims           map[string]interface{} `json:"claims,omitempty"`
+	Reason           string                 `json:"reason,omitempty"`
+	SyntheticJWT     string                 `json:"synthetic_jwt,omitempty"`
+	Agent            *GatewayAgentContext   `json:"agent,omitempty"`
+	APIVersion       string                 `json:"api_version,omitempty"`
 }
 
 // GatewayAgentContext exposes agent metadata when delegation is detected.
 type GatewayAgentContext struct {
-        ActingOnBehalfOf string   `json:"acting_on_behalf_of"`
-        DelegationDepth  int      `json:"delegation_depth"`
-        Scope            []string `json:"scope,omitempty"`
+	ActingOnBehalfOf string   `json:"acting_on_behalf_of"`
+	DelegationDepth  int      `json:"delegation_depth"`
+	Scope            []string `json:"scope,omitempty"`
+}
+
+// APIError models the common error envelope returned by services.
+type APIError struct {
+	Error       string `json:"error"`
+	Description string `json:"description"`
+	Code        string `json:"code"`
+	APIVersion  string `json:"api_version"`
 }


### PR DESCRIPTION
## Summary
- add a consolidated Go client with per-service endpoints, env/local constructors, and SD-JWT helpers
- refresh SDK types, documentation, and module path to match the public github.com/bradtumy/credential-service/sdk-go import
- add a basic Go example that issues, verifies, and authorizes a credential with a synthetic JWT

## Testing
- GOTOOLCHAIN=local GOWORK=off go test -v ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347ed8c75c832cbf196ec8d6f2698d)