### PR TITLE
chore(sdk): canonicalize Go SDK module path to github.com/tumy-tech-labs/credential-service/sdk/go

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to see the raw responses, the script prints the authorize and deny p
 - You need long-lived bearer tokens without rotation—short TTLs and delegation limits are core to the product.
 
 ## SDKs & examples
-- **Go SDK**: `github.com/bradtumy/credential-service/sdk-go` with both low-level and new high-level helpers.
+- **Go SDK**: `github.com/tumy-tech-labs/credential-service/sdk/go` with both low-level and new high-level helpers.
   - Quick local client: `client := sdk.NewMagicLocalClient()`
   - See `examples/go/killer-demo` for a minimal end-to-end call chain.
 - **Node SDK**: see [`sdk/node`](sdk/node/README.md) for parity endpoints.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ internal/            # shared libraries (not importable by SDKs)
   httpserver/        # HTTP handlers, middleware, and route registration
   keystore/          # pluggable keystore backends
   metrics/, policy/, ratelimit/, storage/, tenant/ ...
-sdk/go               # Go SDK (module path: github.com/bradtumy/credential-service/sdk-go)
+sdk/go               # Go SDK (module path: github.com/tumy-tech-labs/credential-service/sdk/go)
 sdk/node             # Node SDK
 ```
 

--- a/examples/go/basic/main.go
+++ b/examples/go/basic/main.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 
-	sdk "github.com/bradtumy/credential-service/sdk-go"
+	sdk "github.com/tumy-tech-labs/credential-service/sdk/go"
 )
 
 func main() {

--- a/examples/sdk-go/sd-jwt/go.mod
+++ b/examples/sdk-go/sd-jwt/go.mod
@@ -2,6 +2,6 @@ module github.com/bradtumy/credential-service/examples/sdk-go/sd-jwt
 
 go 1.21
 
-require github.com/bradtumy/credential-service/sdk-go v0.0.0
+require github.com/tumy-tech-labs/credential-service/sdk/go v0.0.0
 
-replace github.com/bradtumy/credential-service/sdk-go => ../../../sdk/go
+replace github.com/tumy-tech-labs/credential-service/sdk/go => ../../../sdk/go

--- a/examples/sdk-go/sd-jwt/main.go
+++ b/examples/sdk-go/sd-jwt/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	sdk "github.com/bradtumy/credential-service/sdk-go"
+	sdk "github.com/tumy-tech-labs/credential-service/sdk/go"
 	"log"
 	"os"
 )

--- a/examples/sdk-go/sd-jwt2/go.mod
+++ b/examples/sdk-go/sd-jwt2/go.mod
@@ -2,6 +2,6 @@ module github.com/bradtumy/credential-service/examples/sdk-go/sd-jwt2
 
 go 1.21
 
-require github.com/bradtumy/credential-service/sdk-go v0.0.0
+require github.com/tumy-tech-labs/credential-service/sdk/go v0.0.0
 
-replace github.com/bradtumy/credential-service/sdk-go => ../../../sdk/go
+replace github.com/tumy-tech-labs/credential-service/sdk/go => ../../../sdk/go

--- a/examples/sdk-go/sd-jwt2/main.go
+++ b/examples/sdk-go/sd-jwt2/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	sdk "github.com/bradtumy/credential-service/sdk-go"
+	sdk "github.com/tumy-tech-labs/credential-service/sdk/go"
 	"log"
 	"os"
 )

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -5,7 +5,7 @@ A first-class Go client for issuing, verifying, and authorizing credentials with
 ## Installation
 
 ```bash
-go get github.com/bradtumy/credential-service/sdk-go
+go get github.com/tumy-tech-labs/credential-service/sdk/go
 ```
 
 ## Quickstart
@@ -17,7 +17,7 @@ import (
         "context"
         "log"
 
-        sdk "github.com/bradtumy/credential-service/sdk-go"
+        sdk "github.com/tumy-tech-labs/credential-service/sdk/go"
 )
 
 func main() {

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/bradtumy/credential-service/sdk-go
+module github.com/tumy-tech-labs/credential-service/sdk/go
 
 go 1.22


### PR DESCRIPTION
Change the Go SDK module path to match the on-disk folder layout and repository owner.

- Updated  to 
- Updated README and docs references
- Updated example imports and  replace directives

Migration note:
- Local development:  will use the canonical module path. Examples in the repo use  directives to point to the local  folder for development.
- External consumers should update imports from  to .
