### PR TITLE
Add OIDC4VP direct_post response validation

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -119,6 +119,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GatewayAuthorizeResponse'
+  /v1/oidc4vp/response:
+    post:
+      summary: OIDC4VP direct_post response handler
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                state:
+                  type: string
+                vp_token:
+                  type: string
+              required: [state, vp_token]
+      responses:
+        '200':
+          description: VP token verified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OIDC4VPResponse'
+        '400':
+          description: Invalid request or response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
 components:
   schemas:
     HealthResponse:
@@ -262,3 +296,15 @@ components:
         api_version:
           type: string
       required: [error, api_version]
+    OIDC4VPResponse:
+      type: object
+      properties:
+        verified:
+          type: boolean
+        holder_did:
+          type: string
+        credential_count:
+          type: integer
+        api_version:
+          type: string
+      required: [verified, api_version]

--- a/docs/OIDC4VP.md
+++ b/docs/OIDC4VP.md
@@ -1,0 +1,49 @@
+# OIDC4VP (Verifier) — Response Handling
+
+This service now validates OpenID for Verifiable Presentations (OIDC4VP) responses in **direct_post** mode. It does **not** yet expose an authorization request creation endpoint; authorization requests must be created and stored by the verifier frontend or an upstream component. The response handler uses the stored request to validate nonce, state, and credential requirements.
+
+## Supported response flow
+
+* **Response Mode:** `direct_post`
+* **Response Type:** `vp_token`
+* **Credential Query Language:** DCQL (subset)
+* **Formats:**
+  * `jwt_vc_json` (W3C VC-JWT)
+  * `dc+sd-jwt` (SD-JWT VC without holder binding)
+
+## Endpoint
+
+`POST /v1/oidc4vp/response`
+
+`Content-Type: application/x-www-form-urlencoded`
+
+Form parameters:
+
+| Parameter | Required | Notes |
+| --- | --- | --- |
+| `state` | yes | Must match a stored authorization request. |
+| `vp_token` | yes | JSON object keyed by DCQL credential query id. |
+
+On success, the endpoint returns a JSON payload with `verified=true` and the holder DID (if provided in the presentation).
+
+## Validation rules (summary)
+
+* **State** must match a stored request and be unused.
+* **Nonce** is required when the query requires holder binding.
+* **Holder binding**:
+  * For `jwt_vc_json`, the VP JWT must be signed by the holder and bound to `aud=client_id` and the request `nonce`.
+  * For `dc+sd-jwt`, holder binding is **not** supported yet. Requests requiring holder binding for this format are rejected.
+* **Issuer trust** is enforced via the configured trust registry.
+* **Revocation checks** are enforced when `OIDC4VP_REVOCATION_STRICT=true`.
+
+## Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `OIDC4VP_MAX_REQUEST_SIZE` | `262144` | Maximum request body size in bytes. |
+| `OIDC4VP_REVOCATION_STRICT` | `true` | Reject revoked credentials (by VC `id`/`jti`). |
+
+## Notes
+
+* The `dc+sd-jwt` format requires `vct_values` in the credential query metadata. The verifier checks the `vct` claim in the presented SD-JWT VC.
+* For `jwt_vc_json`, `type_values` is required in the credential query metadata and is checked against the credential `type` array.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-        "os"
-        "strconv"
+	"os"
+	"strconv"
 
-        "github.com/bradtumy/credential-service/internal/policy"
+	"github.com/bradtumy/credential-service/internal/policy"
 )
 
 // Config holds application configuration loaded from environment variables.
@@ -42,63 +42,67 @@ func getenv(key, fallback string) string {
 
 // IssuerConfig holds configuration for the issuer service.
 type IssuerConfig struct {
-        HTTPPort        string
-        DefaultTenantID string
-        TenancyMode     string
-        LogLevel        string
-        AuditDB_DSN     string
-        Policy          policy.IssuancePolicy
+	HTTPPort        string
+	DefaultTenantID string
+	TenancyMode     string
+	LogLevel        string
+	AuditDB_DSN     string
+	Policy          policy.IssuancePolicy
 }
 
 // LoadIssuerConfigFromEnv loads issuer configuration from environment variables.
 func LoadIssuerConfigFromEnv() IssuerConfig {
-        return IssuerConfig{
-                HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
-                DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
-                TenancyMode:     getenv("TENANCY_MODE", "single"),
-                LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
-                AuditDB_DSN:     getenv("ISSUER_AUDIT_DB_DSN", ""),
-                Policy:          policy.LoadIssuancePolicyFromEnv(),
-        }
+	return IssuerConfig{
+		HTTPPort:        getenv("ISSUER_HTTP_PORT", "8080"),
+		DefaultTenantID: getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		TenancyMode:     getenv("TENANCY_MODE", "single"),
+		LogLevel:        getenv("ISSUER_LOG_LEVEL", "info"),
+		AuditDB_DSN:     getenv("ISSUER_AUDIT_DB_DSN", ""),
+		Policy:          policy.LoadIssuancePolicyFromEnv(),
+	}
 }
 
 // VerifierConfig holds configuration for the verifier service.
 type VerifierConfig struct {
-	HTTPPort           string
-	DefaultTenantID    string
-	DB_DSN             string
-	UseDBTrustRegistry bool
-	TenancyMode        string
-	LogLevel           string
-	GatewayCache       bool
-	RateLimitEnabled   bool
-	RedisAddr          string
-	RedisPassword      string
-	RedisDB            int
+	HTTPPort                string
+	DefaultTenantID         string
+	DB_DSN                  string
+	UseDBTrustRegistry      bool
+	TenancyMode             string
+	LogLevel                string
+	GatewayCache            bool
+	RateLimitEnabled        bool
+	RedisAddr               string
+	RedisPassword           string
+	RedisDB                 int
+	OIDC4VPMaxRequestSize   int
+	OIDC4VPRevocationStrict bool
 	// DID Resolution Configuration
-	DIDResolutionTimeout int    // Timeout in seconds for DID resolution
-	MaxDIDLength        int    // Maximum allowed DID length
-	DIDResolverDebug    bool   // Enable debug logging for DID resolution
+	DIDResolutionTimeout int  // Timeout in seconds for DID resolution
+	MaxDIDLength         int  // Maximum allowed DID length
+	DIDResolverDebug     bool // Enable debug logging for DID resolution
 }
 
 // LoadVerifierConfigFromEnv loads verifier configuration from environment variables.
 func LoadVerifierConfigFromEnv() VerifierConfig {
 	return VerifierConfig{
-		HTTPPort:           getenv("VERIFIER_HTTP_PORT", "8081"),
-		DefaultTenantID:    getenv("DEFAULT_TENANT_ID", "default-tenant"),
-		DB_DSN:             getenv("VERIFIER_DB_DSN", ""),
-		UseDBTrustRegistry: getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
-		TenancyMode:        getenv("TENANCY_MODE", "single"),
-		LogLevel:           getenv("VERIFIER_LOG_LEVEL", "info"),
-		GatewayCache:       getenv("GATEWAY_CACHE_ENABLED", "false") == "true",
-		RateLimitEnabled:   getenv("RATELIMIT_ENABLED", "false") == "true",
-		RedisAddr:          getenv("REDIS_ADDR", ""),
-		RedisPassword:      getenv("REDIS_PASSWORD", ""),
-		RedisDB:            getenvInt("REDIS_DB", 0),
+		HTTPPort:                getenv("VERIFIER_HTTP_PORT", "8081"),
+		DefaultTenantID:         getenv("DEFAULT_TENANT_ID", "default-tenant"),
+		DB_DSN:                  getenv("VERIFIER_DB_DSN", ""),
+		UseDBTrustRegistry:      getenv("VERIFIER_USE_DB_TRUST_REGISTRY", "false") == "true",
+		TenancyMode:             getenv("TENANCY_MODE", "single"),
+		LogLevel:                getenv("VERIFIER_LOG_LEVEL", "info"),
+		GatewayCache:            getenv("GATEWAY_CACHE_ENABLED", "false") == "true",
+		RateLimitEnabled:        getenv("RATELIMIT_ENABLED", "false") == "true",
+		RedisAddr:               getenv("REDIS_ADDR", ""),
+		RedisPassword:           getenv("REDIS_PASSWORD", ""),
+		RedisDB:                 getenvInt("REDIS_DB", 0),
+		OIDC4VPMaxRequestSize:   getenvInt("OIDC4VP_MAX_REQUEST_SIZE", 262144),
+		OIDC4VPRevocationStrict: getenv("OIDC4VP_REVOCATION_STRICT", "true") == "true",
 		// DID Resolution Configuration
 		DIDResolutionTimeout: getenvInt("DID_RESOLUTION_TIMEOUT", 5), // 5 seconds default
-		MaxDIDLength:        getenvInt("MAX_DID_LENGTH", 2048),       // 2KB default
-		DIDResolverDebug:    getenv("DID_RESOLVER_DEBUG", "false") == "true",
+		MaxDIDLength:         getenvInt("MAX_DID_LENGTH", 2048),      // 2KB default
+		DIDResolverDebug:     getenv("DID_RESOLVER_DEBUG", "false") == "true",
 	}
 }
 

--- a/internal/httpserver/oidc4vp_handlers.go
+++ b/internal/httpserver/oidc4vp_handlers.go
@@ -1,0 +1,151 @@
+package httpserver
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/logging"
+	"github.com/bradtumy/credential-service/internal/oidc4vp"
+	"github.com/bradtumy/credential-service/internal/version"
+)
+
+// OIDC4VPConfig bundles dependencies for OIDC4VP response handling.
+type OIDC4VPConfig struct {
+	RequestStore     oidc4vp.RequestStore
+	IssuerResolver   func(string) (crypto.PublicKey, error)
+	HolderResolver   func(string) (crypto.PublicKey, error)
+	TrustRegistry    domain.TrustRegistry
+	DefaultTenantID  string
+	MaxRequestSize   int64
+	Now              func() time.Time
+	RevocationStrict bool
+}
+
+// OIDC4VPResponse captures the verifier response payload.
+type OIDC4VPResponse struct {
+	Verified        bool   `json:"verified"`
+	HolderDID       string `json:"holder_did,omitempty"`
+	CredentialCount int    `json:"credential_count,omitempty"`
+	APIVersion      string `json:"api_version"`
+}
+
+// RegisterOIDC4VPRoutes registers the OIDC4VP response endpoint.
+func RegisterOIDC4VPRoutes(mux *http.ServeMux, cfg OIDC4VPConfig) {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.MaxRequestSize == 0 {
+		cfg.MaxRequestSize = 256 * 1024
+	}
+
+	mux.HandleFunc("/v1/oidc4vp/response", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			WriteAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+			return
+		}
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "content-type must be application/x-www-form-urlencoded")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, cfg.MaxRequestSize)
+		if err := r.ParseForm(); err != nil {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "invalid form payload")
+			return
+		}
+
+		state := r.PostFormValue("state")
+		vpToken := r.PostFormValue("vp_token")
+		if state == "" || vpToken == "" {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "state and vp_token are required")
+			return
+		}
+		if cfg.RequestStore == nil || cfg.IssuerResolver == nil || cfg.HolderResolver == nil {
+			WriteAPIError(w, http.StatusInternalServerError, "server_error", "request store not configured")
+			return
+		}
+
+		req, err := cfg.RequestStore.Get(r.Context(), state)
+		if err != nil {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "unknown or expired state")
+			return
+		}
+
+		tenantID := TenantIDFromContext(r.Context())
+		if tenantID == "" {
+			tenantID = cfg.DefaultTenantID
+		}
+
+		resolveIssuer := func(issuer string) (crypto.PublicKey, error) {
+			if cfg.TrustRegistry != nil {
+				trusted, err := cfg.TrustRegistry.IsTrustedIssuer(r.Context(), tenantID, issuer)
+				if err != nil {
+					return nil, err
+				}
+				if !trusted {
+					return nil, domain.ErrUntrustedIssuer
+				}
+			}
+			return cfg.IssuerResolver(issuer)
+		}
+
+		result, err := oidc4vp.ValidateResponse(req, vpToken, oidc4vp.ResponseDependencies{
+			ResolveIssuerKey: resolveIssuer,
+			ResolveHolderKey: cfg.HolderResolver,
+			Now:              cfg.Now,
+			RevocationStrict: cfg.RevocationStrict,
+		})
+		if err != nil {
+			status, code := mapOIDC4VPError(err)
+			WriteAPIError(w, status, code, err.Error())
+			logging.LogAuditEvent(r.Context(), logging.AuditEvent{
+				EventType: logging.AuditEventOIDC4VPVerified,
+				Outcome:   "failure",
+				Reason:    code,
+				Metadata: map[string]interface{}{
+					"state": state,
+					"error": err.Error(),
+				},
+			})
+			return
+		}
+
+		if err := cfg.RequestStore.MarkUsed(r.Context(), state); err != nil {
+			WriteAPIError(w, http.StatusBadRequest, "invalid_request", "state already used")
+			return
+		}
+
+		resp := OIDC4VPResponse{
+			Verified:        true,
+			HolderDID:       result.HolderDID,
+			CredentialCount: len(result.Credentials),
+			APIVersion:      version.APIVersion,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+
+		logging.LogAuditEvent(r.Context(), logging.AuditEvent{
+			EventType:  logging.AuditEventOIDC4VPVerified,
+			Outcome:    "success",
+			SubjectDID: result.HolderDID,
+			Metadata: map[string]interface{}{
+				"state":            state,
+				"credential_count": len(result.Credentials),
+			},
+		})
+	})
+}
+
+func mapOIDC4VPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, domain.ErrUntrustedIssuer):
+		return http.StatusForbidden, "access_denied"
+	default:
+		return http.StatusBadRequest, "invalid_request"
+	}
+}

--- a/internal/httpserver/oidc4vp_handlers_test.go
+++ b/internal/httpserver/oidc4vp_handlers_test.go
@@ -1,0 +1,128 @@
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+	"github.com/bradtumy/credential-service/internal/oidc4vp"
+	"github.com/bradtumy/credential-service/internal/version"
+)
+
+func TestOIDC4VPResponseHandlerSuccess(t *testing.T) {
+	issuerPub, issuerPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate issuer key: %v", err)
+	}
+	holderPub, holderPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate holder key: %v", err)
+	}
+
+	issuerDID, _ := domain.DIDFromPublicKey(issuerPub)
+	holderDID, _ := domain.DIDFromPublicKey(holderPub)
+	vcToken, err := domain.IssueBasicCredential(issuerDID, "did:jwk:subject", issuerPriv, 5*time.Minute, map[string]any{"role": "user"})
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	vpJWT := signTestJWT(holderPriv, map[string]any{
+		"iss":   holderDID,
+		"aud":   "client-123",
+		"nonce": "nonce-abc",
+		"vp": map[string]any{
+			"type":                 []string{"VerifiablePresentation"},
+			"verifiableCredential": []string{vcToken},
+		},
+	})
+
+	vpTokenRaw, _ := json.Marshal(map[string][]string{
+		"cred1": {vpJWT},
+	})
+
+	meta := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"type_values":[["VerifiableCredential"]]}`), &meta)
+
+	store := oidc4vp.NewMemoryRequestStore()
+	req := oidc4vp.AuthorizationRequest{
+		ClientID:     "client-123",
+		State:        "state-1",
+		Nonce:        "nonce-abc",
+		ResponseType: "vp_token",
+		DCQLQuery: oidc4vp.DCQLQuery{
+			Credentials: []oidc4vp.CredentialQuery{
+				{ID: "cred1", Format: oidc4vp.FormatJWTVCJSON, Meta: meta},
+			},
+		},
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	if err := store.Save(context.Background(), req); err != nil {
+		t.Fatalf("save request: %v", err)
+	}
+
+	registry := domain.NewMemoryTrustRegistry()
+	if err := registry.AddTrustedIssuer(context.Background(), "tenant", issuerDID); err != nil {
+		t.Fatalf("trust issuer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	RegisterOIDC4VPRoutes(mux, OIDC4VPConfig{
+		RequestStore:     store,
+		IssuerResolver:   func(issuer string) (crypto.PublicKey, error) { return issuerPub, nil },
+		HolderResolver:   func(holder string) (crypto.PublicKey, error) { return holderPub, nil },
+		TrustRegistry:    registry,
+		DefaultTenantID:  "tenant",
+		MaxRequestSize:   64 * 1024,
+		Now:              time.Now,
+		RevocationStrict: true,
+	})
+
+	form := url.Values{}
+	form.Set("state", "state-1")
+	form.Set("vp_token", string(vpTokenRaw))
+
+	reqHTTP := httptest.NewRequest(http.MethodPost, "/v1/oidc4vp/response", bytes.NewBufferString(form.Encode()))
+	reqHTTP.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	recorder := httptest.NewRecorder()
+
+	mux.ServeHTTP(recorder, reqHTTP)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", recorder.Code)
+	}
+
+	var resp OIDC4VPResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Verified || resp.APIVersion != version.APIVersion {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	// replay should fail
+	recorder = httptest.NewRecorder()
+	mux.ServeHTTP(recorder, reqHTTP)
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("expected replay to fail")
+	}
+}
+
+func signTestJWT(signer ed25519.PrivateKey, payload map[string]any) string {
+	header := map[string]any{"alg": "EdDSA", "typ": "JWT"}
+	headerBytes, _ := json.Marshal(header)
+	payloadBytes, _ := json.Marshal(payload)
+	headerSegment := base64.RawURLEncoding.EncodeToString(headerBytes)
+	payloadSegment := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signingInput := headerSegment + "." + payloadSegment
+	signature := ed25519.Sign(signer, []byte(signingInput))
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -16,7 +16,7 @@ var Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level:
 // Initialize to a sane default to avoid nil dereferences in tests/services
 // that don't explicitly call Init(). Init() will override this.
 var AuditLogger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-	Level:    slog.LevelInfo,
+	Level:     slog.LevelInfo,
 	AddSource: true,
 }))
 
@@ -37,9 +37,9 @@ type AuditEventType string
 
 const (
 	// Authentication and authorization events
-	AuditEventLogin          AuditEventType = "auth.login"
-	AuditEventLogout         AuditEventType = "auth.logout"
-	AuditEventAccessDenied   AuditEventType = "auth.access_denied"
+	AuditEventLogin           AuditEventType = "auth.login"
+	AuditEventLogout          AuditEventType = "auth.logout"
+	AuditEventAccessDenied    AuditEventType = "auth.access_denied"
 	AuditEventPermissionGrant AuditEventType = "auth.permission_grant"
 
 	// Credential lifecycle events
@@ -47,6 +47,7 @@ const (
 	AuditEventCredentialVerified AuditEventType = "credential.verified"
 	AuditEventCredentialRevoked  AuditEventType = "credential.revoked"
 	AuditEventDelegationCreated  AuditEventType = "credential.delegation_created"
+	AuditEventOIDC4VPVerified    AuditEventType = "oidc4vp.verified"
 
 	// Administrative events
 	AuditEventTrustRegistryUpdate AuditEventType = "admin.trust_registry_update"
@@ -57,10 +58,10 @@ const (
 	AuditEventConfigChange        AuditEventType = "admin.config_change"
 
 	// Security events
-	AuditEventSecurityIncident    AuditEventType = "security.incident"
-	AuditEventRateLimitExceeded   AuditEventType = "security.rate_limit_exceeded"
-	AuditEventSuspiciousActivity  AuditEventType = "security.suspicious_activity"
-	AuditEventDataAccess          AuditEventType = "security.data_access"
+	AuditEventSecurityIncident   AuditEventType = "security.incident"
+	AuditEventRateLimitExceeded  AuditEventType = "security.rate_limit_exceeded"
+	AuditEventSuspiciousActivity AuditEventType = "security.suspicious_activity"
+	AuditEventDataAccess         AuditEventType = "security.data_access"
 )
 
 // AuditEvent represents a structured audit log entry.
@@ -88,7 +89,7 @@ func Init(level string) {
 
 	// Initialize audit logger with structured format
 	auditHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level:     slog.LevelInfo,
 		AddSource: true,
 	})
 	AuditLogger = slog.New(auditHandler)
@@ -143,19 +144,19 @@ func GetUserID(ctx context.Context) string {
 // ContextLogger returns a logger with context values pre-populated.
 func ContextLogger(ctx context.Context) *slog.Logger {
 	logger := Logger
-	
+
 	if correlationID := GetCorrelationID(ctx); correlationID != "" {
 		logger = logger.With("correlation_id", correlationID)
 	}
-	
+
 	if tenantID := GetTenantID(ctx); tenantID != "" {
 		logger = logger.With("tenant_id", tenantID)
 	}
-	
+
 	if userID := GetUserID(ctx); userID != "" {
 		logger = logger.With("user_id", userID)
 	}
-	
+
 	return logger
 }
 
@@ -178,20 +179,20 @@ func LogAuditEvent(ctx context.Context, event AuditEvent) {
 	if event.CorrelationID == "" {
 		event.CorrelationID = GetCorrelationID(ctx)
 	}
-	
+
 	// Populate tenant ID from context if not set
 	if event.TenantID == "" {
 		event.TenantID = GetTenantID(ctx)
 	}
-	
+
 	// Populate user ID from context if not set
 	if event.UserID == "" {
 		event.UserID = GetUserID(ctx)
 	}
-	
+
 	// Set timestamp
 	event.Timestamp = time.Now().UTC()
-	
+
 	// Use AuditLogger if set; otherwise fall back to slog.Default()
 	logger := AuditLogger
 	if logger == nil {

--- a/internal/oidc4vp/store.go
+++ b/internal/oidc4vp/store.go
@@ -1,0 +1,75 @@
+package oidc4vp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// RequestStore persists authorization requests for OIDC4VP responses.
+type RequestStore interface {
+	Save(ctx context.Context, req AuthorizationRequest) error
+	Get(ctx context.Context, state string) (AuthorizationRequest, error)
+	MarkUsed(ctx context.Context, state string) error
+}
+
+// MemoryRequestStore stores requests in memory with basic TTL enforcement.
+type MemoryRequestStore struct {
+	mu      sync.RWMutex
+	records map[string]requestRecord
+}
+
+type requestRecord struct {
+	request AuthorizationRequest
+	used    bool
+}
+
+// NewMemoryRequestStore constructs an in-memory request store.
+func NewMemoryRequestStore() *MemoryRequestStore {
+	return &MemoryRequestStore{records: make(map[string]requestRecord)}
+}
+
+// Save stores a request by its state value.
+func (s *MemoryRequestStore) Save(_ context.Context, req AuthorizationRequest) error {
+	if req.State == "" {
+		return errors.New("state is required")
+	}
+	if req.ExpiresAt.IsZero() {
+		req.ExpiresAt = time.Now().Add(5 * time.Minute)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[req.State] = requestRecord{request: req}
+	return nil
+}
+
+// Get returns a request by state, enforcing expiration.
+func (s *MemoryRequestStore) Get(_ context.Context, state string) (AuthorizationRequest, error) {
+	s.mu.RLock()
+	record, ok := s.records[state]
+	s.mu.RUnlock()
+	if !ok {
+		return AuthorizationRequest{}, errors.New("request not found")
+	}
+	if !record.request.ExpiresAt.IsZero() && time.Now().After(record.request.ExpiresAt) {
+		return AuthorizationRequest{}, errors.New("request expired")
+	}
+	return record.request, nil
+}
+
+// MarkUsed marks a request as used to prevent replay.
+func (s *MemoryRequestStore) MarkUsed(_ context.Context, state string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[state]
+	if !ok {
+		return errors.New("request not found")
+	}
+	if record.used {
+		return errors.New("request already used")
+	}
+	record.used = true
+	s.records[state] = record
+	return nil
+}

--- a/internal/oidc4vp/types.go
+++ b/internal/oidc4vp/types.go
@@ -1,0 +1,151 @@
+package oidc4vp
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+const (
+	FormatJWTVCJSON = "jwt_vc_json"
+	FormatSDJWTVC   = "dc+sd-jwt"
+)
+
+var (
+	errEmptyID          = errors.New("credential query id is required")
+	errInvalidID        = errors.New("credential query id format is invalid")
+	errDuplicateID      = errors.New("duplicate credential query id")
+	errMissingFormat    = errors.New("credential query format is required")
+	errMissingMeta      = errors.New("credential query meta is required")
+	errMissingOptions   = errors.New("credential set options are required")
+	errMissingClaimPath = errors.New("claim path is required")
+)
+
+var queryIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// AuthorizationRequest captures the parameters required to validate an OIDC4VP response.
+type AuthorizationRequest struct {
+	ClientID     string
+	ResponseURI  string
+	State        string
+	Nonce        string
+	ResponseType string
+	ResponseMode string
+	DCQLQuery    DCQLQuery
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}
+
+// DCQLQuery describes the Verifier's credential request.
+type DCQLQuery struct {
+	Credentials     []CredentialQuery    `json:"credentials"`
+	CredentialSets  []CredentialSetQuery `json:"credential_sets,omitempty"`
+	TransactionData []any                `json:"transaction_data,omitempty"`
+}
+
+// CredentialQuery captures a request for a credential presentation.
+type CredentialQuery struct {
+	ID                                string             `json:"id"`
+	Format                            string             `json:"format"`
+	Multiple                          bool               `json:"multiple,omitempty"`
+	Meta                              map[string]any     `json:"meta"`
+	TrustedAuthorities                []TrustedAuthority `json:"trusted_authorities,omitempty"`
+	RequireCryptographicHolderBinding *bool              `json:"require_cryptographic_holder_binding,omitempty"`
+	Claims                            []ClaimQuery       `json:"claims,omitempty"`
+	ClaimSets                         [][]string         `json:"claim_sets,omitempty"`
+}
+
+// CredentialSetQuery captures a set of credential options.
+type CredentialSetQuery struct {
+	Options  [][]string `json:"options"`
+	Required *bool      `json:"required,omitempty"`
+}
+
+// ClaimQuery captures a requested claim path and optional expected values.
+type ClaimQuery struct {
+	ID     string   `json:"id,omitempty"`
+	Path   []string `json:"path"`
+	Values []any    `json:"values,omitempty"`
+}
+
+// TrustedAuthority captures issuer constraints in DCQL.
+type TrustedAuthority struct {
+	Name   string `json:"name,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+// Validate ensures the authorization request is well-formed for response validation.
+func (r AuthorizationRequest) Validate() error {
+	if r.ClientID == "" {
+		return errors.New("client_id is required")
+	}
+	if r.State == "" {
+		return errors.New("state is required")
+	}
+	if r.ResponseType == "" {
+		return errors.New("response_type is required")
+	}
+	if err := r.DCQLQuery.Validate(); err != nil {
+		return fmt.Errorf("dcql_query: %w", err)
+	}
+	return nil
+}
+
+// Validate ensures the DCQL query is well-formed for response validation.
+func (q DCQLQuery) Validate() error {
+	if len(q.Credentials) == 0 {
+		return errors.New("credentials are required")
+	}
+	seen := map[string]struct{}{}
+	for _, cred := range q.Credentials {
+		if cred.ID == "" {
+			return errEmptyID
+		}
+		if !queryIDPattern.MatchString(cred.ID) {
+			return errInvalidID
+		}
+		if _, ok := seen[cred.ID]; ok {
+			return errDuplicateID
+		}
+		seen[cred.ID] = struct{}{}
+		if cred.Format == "" {
+			return errMissingFormat
+		}
+		if cred.Meta == nil {
+			return errMissingMeta
+		}
+		if err := cred.ValidateClaims(); err != nil {
+			return err
+		}
+	}
+	for _, set := range q.CredentialSets {
+		if len(set.Options) == 0 {
+			return errMissingOptions
+		}
+		for _, option := range set.Options {
+			if len(option) == 0 {
+				return errMissingOptions
+			}
+		}
+	}
+	return nil
+}
+
+// HolderBindingRequired returns whether holder binding is required by the query.
+func (q CredentialQuery) HolderBindingRequired() bool {
+	if q.RequireCryptographicHolderBinding == nil {
+		return true
+	}
+	return *q.RequireCryptographicHolderBinding
+}
+
+// ValidateClaims ensures claims query fields are valid.
+func (q CredentialQuery) ValidateClaims() error {
+	for _, claim := range q.Claims {
+		if len(claim.Path) == 0 {
+			return errMissingClaimPath
+		}
+	}
+	return nil
+}

--- a/internal/oidc4vp/validation.go
+++ b/internal/oidc4vp/validation.go
@@ -1,0 +1,502 @@
+package oidc4vp
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+const (
+	maxVPTokenSize = 128 * 1024
+)
+
+// ResponseDependencies defines collaborators needed to validate responses.
+type ResponseDependencies struct {
+	ResolveIssuerKey func(string) (crypto.PublicKey, error)
+	ResolveHolderKey func(string) (crypto.PublicKey, error)
+	Now              func() time.Time
+	RevocationStrict bool
+}
+
+// ValidationResult captures the outcome of a response validation.
+type ValidationResult struct {
+	HolderDID       string
+	Credentials     []domain.VerifiableCredential
+	PresentationIDs []string
+}
+
+// ValidateResponse validates an OIDC4VP response payload.
+func ValidateResponse(req AuthorizationRequest, vpTokenRaw string, deps ResponseDependencies) (*ValidationResult, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	if req.ResponseType != "vp_token" {
+		return nil, errors.New("unsupported response_type")
+	}
+	if vpTokenRaw == "" {
+		return nil, errors.New("vp_token is required")
+	}
+	if len(vpTokenRaw) > maxVPTokenSize {
+		return nil, errors.New("vp_token too large")
+	}
+	if deps.ResolveIssuerKey == nil || deps.ResolveHolderKey == nil {
+		return nil, errors.New("missing key resolvers")
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+
+	vpToken, err := parseVPToken(vpTokenRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	queries := map[string]CredentialQuery{}
+	for _, query := range req.DCQLQuery.Credentials {
+		queries[query.ID] = query
+		if query.HolderBindingRequired() && req.Nonce == "" {
+			return nil, errors.New("nonce required for holder binding")
+		}
+	}
+
+	for id := range vpToken {
+		if _, ok := queries[id]; !ok {
+			return nil, fmt.Errorf("unexpected credential query id: %s", id)
+		}
+	}
+
+	if err := verifyCredentialSetRequirements(req.DCQLQuery, vpToken); err != nil {
+		return nil, err
+	}
+
+	verifierDeps := domain.VerifierDependencies{ResolveIssuerPublicKey: deps.ResolveIssuerKey}
+	result := &ValidationResult{}
+
+	for id, presentations := range vpToken {
+		query := queries[id]
+		if !query.Multiple && len(presentations) > 1 {
+			return nil, fmt.Errorf("credential query %s does not allow multiple presentations", id)
+		}
+
+		for _, presentation := range presentations {
+			holder, credentials, err := validatePresentation(req, query, presentation, deps)
+			if err != nil {
+				return nil, err
+			}
+			if holder != "" {
+				result.HolderDID = holder
+			}
+
+			for _, credentialToken := range credentials {
+				verified, err := domain.VerifyCredentialChain([]string{credentialToken}, verifierDeps, domain.VerificationOptions{}, deps.Now())
+				if err != nil {
+					return nil, err
+				}
+				leaf := verified.Credentials[len(verified.Credentials)-1]
+				if deps.RevocationStrict {
+					id := credentialIDForRevocation(leaf)
+					if id == "" {
+						return nil, errors.New("credential id missing for revocation check")
+					}
+					if revoked, reason := domain.IsRevoked(id); revoked {
+						if reason == "" {
+							reason = "revoked"
+						}
+						return nil, fmt.Errorf("credential revoked: %s", reason)
+					}
+				}
+				if err := validateCredentialMetadata(query, leaf); err != nil {
+					return nil, err
+				}
+				if err := validateClaimQueries(query, leaf.Claims); err != nil {
+					return nil, err
+				}
+				result.Credentials = append(result.Credentials, leaf)
+				result.PresentationIDs = append(result.PresentationIDs, id)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func parseVPToken(raw string) (map[string][]string, error) {
+	var token map[string][]string
+	if err := json.Unmarshal([]byte(raw), &token); err == nil {
+		return token, nil
+	}
+
+	var generic map[string]any
+	if err := json.Unmarshal([]byte(raw), &generic); err != nil {
+		return nil, errors.New("vp_token must be a JSON object")
+	}
+	parsed := make(map[string][]string, len(generic))
+	for key, value := range generic {
+		values, err := toStringSlice(value)
+		if err != nil {
+			return nil, fmt.Errorf("vp_token entry %s: %w", key, err)
+		}
+		parsed[key] = values
+	}
+	return parsed, nil
+}
+
+func toStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case string:
+		return []string{v}, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			str, ok := item.(string)
+			if !ok || str == "" {
+				return nil, errors.New("presentation value must be a string")
+			}
+			out = append(out, str)
+		}
+		return out, nil
+	default:
+		return nil, errors.New("presentations must be string or array")
+	}
+}
+
+func verifyCredentialSetRequirements(query DCQLQuery, vpToken map[string][]string) error {
+	if len(query.CredentialSets) == 0 {
+		for _, cred := range query.Credentials {
+			if len(vpToken[cred.ID]) == 0 {
+				return fmt.Errorf("missing required credential query id: %s", cred.ID)
+			}
+		}
+		return nil
+	}
+
+	for _, set := range query.CredentialSets {
+		required := true
+		if set.Required != nil {
+			required = *set.Required
+		}
+		if !required {
+			continue
+		}
+		matched := false
+		for _, option := range set.Options {
+			if len(option) == 0 {
+				continue
+			}
+			ok := true
+			for _, id := range option {
+				if len(vpToken[id]) == 0 {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return errors.New("required credential set not satisfied")
+		}
+	}
+	return nil
+}
+
+func validatePresentation(req AuthorizationRequest, query CredentialQuery, presentation string, deps ResponseDependencies) (string, []string, error) {
+	holderBinding := query.HolderBindingRequired()
+
+	switch query.Format {
+	case FormatJWTVCJSON:
+		return validateJWTPresentation(req, holderBinding, presentation, deps)
+	case FormatSDJWTVC:
+		if holderBinding {
+			return "", nil, errors.New("holder binding required but not supported for dc+sd-jwt")
+		}
+		return "", []string{presentation}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported credential format: %s", query.Format)
+	}
+}
+
+func validateJWTPresentation(req AuthorizationRequest, holderBindingRequired bool, presentation string, deps ResponseDependencies) (string, []string, error) {
+	if !isJWT(presentation) {
+		if holderBindingRequired {
+			return "", nil, errors.New("holder binding required but presentation is not a JWT VP")
+		}
+		return "", []string{presentation}, nil
+	}
+
+	payload, err := parseAndVerifyJWT(presentation, deps.ResolveHolderKey)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := validateJWTTimeClaims(payload, deps.Now()); err != nil {
+		return "", nil, err
+	}
+
+	holder, _ := payload["iss"].(string)
+	if holderBindingRequired {
+		if err := validateAudience(payload["aud"], req.ClientID); err != nil {
+			return "", nil, err
+		}
+		nonce, _ := payload["nonce"].(string)
+		if nonce == "" || nonce != req.Nonce {
+			return "", nil, errors.New("nonce mismatch")
+		}
+	}
+
+	vp, ok := payload["vp"].(map[string]any)
+	if !ok {
+		return "", nil, errors.New("vp claim missing")
+	}
+	credentials, err := extractCredentials(vp["verifiableCredential"])
+	if err != nil {
+		return "", nil, err
+	}
+	if len(credentials) == 0 {
+		return "", nil, errors.New("verifiableCredential is empty")
+	}
+
+	return holder, credentials, nil
+}
+
+func isJWT(value string) bool {
+	return strings.Count(value, ".") == 2
+}
+
+func parseAndVerifyJWT(token string, resolveKey func(string) (crypto.PublicKey, error)) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("invalid jwt")
+	}
+
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, errors.New("invalid jwt header")
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, errors.New("invalid jwt header")
+	}
+	if alg, _ := header["alg"].(string); alg != "EdDSA" {
+		return nil, fmt.Errorf("unsupported jwt algorithm: %v", header["alg"])
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, errors.New("invalid jwt payload")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, errors.New("invalid jwt payload")
+	}
+
+	issuer, _ := payload["iss"].(string)
+	if issuer == "" {
+		return nil, errors.New("issuer missing")
+	}
+
+	publicKey, err := resolveKey(issuer)
+	if err != nil {
+		return nil, err
+	}
+	edKey, ok := publicKey.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("unsupported holder key type")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, errors.New("invalid jwt signature")
+	}
+	if !ed25519.Verify(edKey, []byte(signingInput), sigBytes) {
+		return nil, errors.New("invalid jwt signature")
+	}
+
+	return payload, nil
+}
+
+func validateJWTTimeClaims(payload map[string]any, now time.Time) error {
+	if exp, ok := payload["exp"].(float64); ok {
+		if now.Unix() >= int64(exp) {
+			return errors.New("presentation has expired")
+		}
+	}
+	if iat, ok := payload["iat"].(float64); ok {
+		if int64(iat) > now.Add(time.Minute).Unix() {
+			return errors.New("presentation issued in the future")
+		}
+	}
+	return nil
+}
+
+func validateAudience(aud any, expected string) error {
+	if expected == "" {
+		return nil
+	}
+	switch v := aud.(type) {
+	case string:
+		if v != expected {
+			return errors.New("audience mismatch")
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == expected {
+				return nil
+			}
+		}
+		return errors.New("audience mismatch")
+	default:
+		return errors.New("audience missing")
+	}
+	return nil
+}
+
+func extractCredentials(value any) ([]string, error) {
+	switch v := value.(type) {
+	case string:
+		return []string{v}, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, errors.New("credential must be a string")
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, errors.New("verifiableCredential must be a string or array")
+	}
+}
+
+func credentialIDForRevocation(credential domain.VerifiableCredential) string {
+	if credential.ID != "" {
+		return credential.ID
+	}
+	if credential.JTI != "" {
+		return credential.JTI
+	}
+	return ""
+}
+
+func validateCredentialMetadata(query CredentialQuery, credential domain.VerifiableCredential) error {
+	switch query.Format {
+	case FormatJWTVCJSON:
+		return validateTypeValues(query.Meta, credential.Type)
+	case FormatSDJWTVC:
+		return validateVCTValues(query.Meta, credential.Claims)
+	default:
+		return nil
+	}
+}
+
+func validateTypeValues(meta map[string]any, types []string) error {
+	raw, ok := meta["type_values"]
+	if !ok {
+		return errors.New("type_values is required for jwt_vc_json")
+	}
+	options, ok := raw.([]any)
+	if !ok {
+		return errors.New("type_values must be an array")
+	}
+	for _, option := range options {
+		requiredTypes, ok := option.([]any)
+		if !ok || len(requiredTypes) == 0 {
+			continue
+		}
+		if containsAll(types, requiredTypes) {
+			return nil
+		}
+	}
+	return errors.New("credential type does not match request")
+}
+
+func validateVCTValues(meta map[string]any, claims map[string]any) error {
+	raw, ok := meta["vct_values"]
+	if !ok {
+		return errors.New("vct_values is required for dc+sd-jwt")
+	}
+	values, ok := raw.([]any)
+	if !ok || len(values) == 0 {
+		return errors.New("vct_values must be a non-empty array")
+	}
+	vct, _ := claims["vct"].(string)
+	if vct == "" {
+		return errors.New("vct claim missing")
+	}
+	for _, value := range values {
+		if v, ok := value.(string); ok && v == vct {
+			return nil
+		}
+	}
+	return errors.New("vct claim does not match request")
+}
+
+func containsAll(actual []string, required []any) bool {
+	for _, item := range required {
+		needle, ok := item.(string)
+		if !ok || needle == "" {
+			return false
+		}
+		found := false
+		for _, value := range actual {
+			if value == needle {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func validateClaimQueries(query CredentialQuery, claims map[string]any) error {
+	for _, claim := range query.Claims {
+		value, ok := lookupClaimPath(claims, claim.Path)
+		if !ok {
+			return fmt.Errorf("claim not found: %v", claim.Path)
+		}
+		if len(claim.Values) > 0 {
+			matched := false
+			for _, expected := range claim.Values {
+				if reflect.DeepEqual(value, expected) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return fmt.Errorf("claim value mismatch: %v", claim.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func lookupClaimPath(claims map[string]any, path []string) (any, bool) {
+	var current any = claims
+	for _, segment := range path {
+		asMap, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		value, ok := asMap[segment]
+		if !ok {
+			return nil, false
+		}
+		current = value
+	}
+	return current, true
+}

--- a/internal/oidc4vp/validation_test.go
+++ b/internal/oidc4vp/validation_test.go
@@ -1,0 +1,189 @@
+package oidc4vp
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/credential-service/internal/domain"
+)
+
+func TestValidateResponseJWTVC(t *testing.T) {
+	issuerPub, issuerPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate issuer key: %v", err)
+	}
+	holderPub, holderPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate holder key: %v", err)
+	}
+
+	issuerDID, err := domain.DIDFromPublicKey(issuerPub)
+	if err != nil {
+		t.Fatalf("issuer did: %v", err)
+	}
+	holderDID, err := domain.DIDFromPublicKey(holderPub)
+	if err != nil {
+		t.Fatalf("holder did: %v", err)
+	}
+
+	vcToken, err := domain.IssueBasicCredential(issuerDID, "did:jwk:subject", issuerPriv, 5*time.Minute, map[string]any{"role": "user"})
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+
+	vpJWT := signJWT(t, holderPriv, map[string]any{
+		"iss":   holderDID,
+		"aud":   "client-123",
+		"nonce": "nonce-abc",
+		"vp": map[string]any{
+			"type":                 []string{"VerifiablePresentation"},
+			"verifiableCredential": []string{vcToken},
+		},
+	})
+
+	vpTokenRaw, _ := json.Marshal(map[string][]string{
+		"cred1": {vpJWT},
+	})
+
+	meta := map[string]any{}
+	if err := json.Unmarshal([]byte(`{"type_values":[["VerifiableCredential"]]}`), &meta); err != nil {
+		t.Fatalf("parse meta: %v", err)
+	}
+
+	req := AuthorizationRequest{
+		ClientID:     "client-123",
+		State:        "state-1",
+		Nonce:        "nonce-abc",
+		ResponseType: "vp_token",
+		DCQLQuery: DCQLQuery{
+			Credentials: []CredentialQuery{
+				{
+					ID:     "cred1",
+					Format: FormatJWTVCJSON,
+					Meta:   meta,
+				},
+			},
+		},
+	}
+
+	result, err := ValidateResponse(req, string(vpTokenRaw), ResponseDependencies{
+		ResolveIssuerKey: func(issuer string) (crypto.PublicKey, error) {
+			if issuer != issuerDID {
+				return nil, domain.ErrUntrustedIssuer
+			}
+			return issuerPub, nil
+		},
+		ResolveHolderKey: func(holder string) (crypto.PublicKey, error) {
+			if holder != holderDID {
+				return nil, domain.ErrUntrustedIssuer
+			}
+			return holderPub, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("validate response: %v", err)
+	}
+	if result.HolderDID != holderDID {
+		t.Fatalf("expected holder %s got %s", holderDID, result.HolderDID)
+	}
+	if len(result.Credentials) != 1 {
+		t.Fatalf("expected 1 credential got %d", len(result.Credentials))
+	}
+}
+
+func TestValidateResponseRevoked(t *testing.T) {
+	issuerPub, issuerPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate issuer key: %v", err)
+	}
+	holderPub, holderPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate holder key: %v", err)
+	}
+
+	issuerDID, _ := domain.DIDFromPublicKey(issuerPub)
+	holderDID, _ := domain.DIDFromPublicKey(holderPub)
+	vcToken, err := domain.IssueBasicCredential(issuerDID, "did:jwk:subject", issuerPriv, 5*time.Minute, map[string]any{"role": "user"})
+	if err != nil {
+		t.Fatalf("issue credential: %v", err)
+	}
+	credentialID := extractJTI(t, vcToken)
+	domain.AddRevocation(credentialID, "revoked")
+	t.Cleanup(func() { domain.RemoveRevocation(credentialID) })
+
+	vpJWT := signJWT(t, holderPriv, map[string]any{
+		"iss":   holderDID,
+		"aud":   "client-123",
+		"nonce": "nonce-abc",
+		"vp": map[string]any{
+			"type":                 []string{"VerifiablePresentation"},
+			"verifiableCredential": []string{vcToken},
+		},
+	})
+
+	vpTokenRaw, _ := json.Marshal(map[string][]string{
+		"cred1": {vpJWT},
+	})
+
+	meta := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"type_values":[["VerifiableCredential"]]}`), &meta)
+
+	req := AuthorizationRequest{
+		ClientID:     "client-123",
+		State:        "state-1",
+		Nonce:        "nonce-abc",
+		ResponseType: "vp_token",
+		DCQLQuery: DCQLQuery{
+			Credentials: []CredentialQuery{
+				{ID: "cred1", Format: FormatJWTVCJSON, Meta: meta},
+			},
+		},
+	}
+
+	_, err = ValidateResponse(req, string(vpTokenRaw), ResponseDependencies{
+		ResolveIssuerKey: func(issuer string) (crypto.PublicKey, error) { return issuerPub, nil },
+		ResolveHolderKey: func(holder string) (crypto.PublicKey, error) { return holderPub, nil },
+		RevocationStrict: true,
+	})
+	if err == nil {
+		t.Fatalf("expected revocation error")
+	}
+}
+
+func signJWT(t *testing.T, signer ed25519.PrivateKey, payload map[string]any) string {
+	t.Helper()
+	header := map[string]any{"alg": "EdDSA", "typ": "JWT"}
+	headerBytes, _ := json.Marshal(header)
+	payloadBytes, _ := json.Marshal(payload)
+	headerSegment := base64.RawURLEncoding.EncodeToString(headerBytes)
+	payloadSegment := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signingInput := headerSegment + "." + payloadSegment
+	signature := ed25519.Sign(signer, []byte(signingInput))
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func extractJTI(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid token")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	jti, _ := payload["jti"].(string)
+	if jti == "" {
+		t.Fatalf("jti missing")
+	}
+	return jti
+}

--- a/services/verifier/server.go
+++ b/services/verifier/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bradtumy/credential-service/internal/keystore"
 	"github.com/bradtumy/credential-service/internal/logging"
 	"github.com/bradtumy/credential-service/internal/metrics"
+	"github.com/bradtumy/credential-service/internal/oidc4vp"
 	"github.com/bradtumy/credential-service/internal/policy"
 	"github.com/bradtumy/credential-service/internal/ratelimit"
 	"github.com/bradtumy/credential-service/internal/storage"
@@ -155,6 +156,18 @@ func NewServer(ctx context.Context, cfg config.VerifierConfig) (*Server, error) 
 
 	mux := http.NewServeMux()
 	httpserver.RegisterVerifierRoutes(mux, resolver, trustRegistry, cfg.DefaultTenantID, verifierMetrics, time.Now)
+
+	oidc4vpStore := oidc4vp.NewMemoryRequestStore()
+	httpserver.RegisterOIDC4VPRoutes(mux, httpserver.OIDC4VPConfig{
+		RequestStore:     oidc4vpStore,
+		IssuerResolver:   resolver,
+		HolderResolver:   func(holder string) (crypto.PublicKey, error) { return didResolver.ResolvePublicKey(ctx, holder) },
+		TrustRegistry:    trustRegistry,
+		DefaultTenantID:  cfg.DefaultTenantID,
+		MaxRequestSize:   int64(cfg.OIDC4VPMaxRequestSize),
+		Now:              time.Now,
+		RevocationStrict: cfg.OIDC4VPRevocationStrict,
+	})
 
 	var decisionCache cache.DecisionCache = cache.NoopDecisionCache{}
 	if cfg.GatewayCache && cfg.RedisAddr != "" {


### PR DESCRIPTION
### Motivation
- Implement server-side validation for OpenID for Verifiable Presentations (OIDC4VP) responses received via the `direct_post` response mode so the verifier can consume VP tokens produced by wallets and enforce holder binding, DCQL requests, issuer trust, and revocation checks.
- Provide a minimal in-memory persistence for authorization requests and replay protection to allow the verifier to map incoming responses to stored authorization requests.

### Description
- Add a new `internal/oidc4vp` package with DCQL data structures, validation logic, in-memory request store, and unit tests; key files are `types.go`, `store.go`, `validation.go`, and `validation_test.go`.
- Implement `POST /v1/oidc4vp/response` handler in `internal/httpserver/oidc4vp_handlers.go` that parses `application/x-www-form-urlencoded` responses, resolves issuer/holder keys, enforces trust registry checks, marks states used, and emits audit events.
- Wire the handler into the verifier service (`services/verifier/server.go`), add configuration toggles (`internal/config/config.go`) and OpenAPI schema (`api/openapi.yaml`), and add documentation (`docs/OIDC4VP.md`).
- Update logging audit event types and add tests for the HTTP handler (`internal/httpserver/oidc4vp_handlers_test.go`) covering successful verification and replay protection.

### Testing
- Created unit tests `internal/oidc4vp/validation_test.go` and `internal/httpserver/oidc4vp_handlers_test.go` and ran `go test ./internal/oidc4vp ./internal/httpserver` which was started but hung and was interrupted. 
- Ran a focused test `go test ./internal/oidc4vp -run TestValidateResponse` which was also started but interrupted (hung) before completion. 
- Note: tests were added and exercised locally in the rollout, but the automated `go test` runs in this environment did not complete due to a hang; further CI/test runs are recommended before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687c255220832c9011240e669978e8)